### PR TITLE
ci+scripts: Add version check scripts + GHA job.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v4
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "6.0.x"
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v4
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "6.0.x"
       - name: Install dependencies

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,9 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  version-check:
-    name: Check Version for NuGet package
+  version-update:
+    name: Automatic Version Updater
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
@@ -28,15 +31,37 @@ jobs:
         run: |
           VERSION=$(./scripts/get-csproj-version.sh Styra/Styra.csproj)
           echo "dotnet_proj_version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Compare the two, failing if there's a diff.
+      - name: Checkout PR
+        if: ${{ steps.speakeasy_version.outputs.speakeasy_version != steps.dotnet_proj_version.outputs.dotnet_proj_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+      - name: Add comment to PR thread
+        if: ${{ steps.speakeasy_version.outputs.speakeasy_version != steps.dotnet_proj_version.outputs.dotnet_proj_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo ':information_source: This PR has been updated with an automated commit. Please Close and Reopen the PR to trigger normal CI checks.' >> comment.txt
+          echo '' >> comment.txt
+          echo 'To fetch the new commits down for local use, try the following git operations:' >> comment.txt
+          echo '```' >> comment.txt
+          echo 'git fetch origin refs/pull/${{ github.event.pull_request.number }}/head:pr_${{ github.event.pull_request.number }}' >> comment.txt
+          echo 'git merge pr_${{ github.event.pull_request.number }}' >> comment.txt
+          echo '```' >> comment.txt
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.txt
+      - name: Compare the two. Forcibly update with a commit if there's a diff.
         if: ${{ steps.speakeasy_version.outputs.speakeasy_version != steps.dotnet_proj_version.outputs.dotnet_proj_version }}
         run: |
           SE_VERSION=${{ steps.speakeasy_version.outputs.speakeasy_version }}
           DOTNET_VERSION=${{ steps.dotnet_proj_version.outputs.dotnet_proj_version }}
           echo "Version mismatch. Speakeasy ver: ${SE_VERSION}, .NET project ver: ${DOTNET_VERSION}"
-          echo "To update the .NET project version, try this sed command, and then commit the changes:"
-          echo "  sed -i \"s/<Version>[^<]*<\/Version>/<Version>${SE_VERSION}<\/Version>/\" Styra/Styra.csproj"
-          exit 1
+          echo "Updating the .NET project version..."
+          sed -i "s/<Version>[^<]*<\/Version>/<Version>${SE_VERSION}<\/Version>/" Styra/Styra.csproj
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add Styra/Styra.csproj
+          git commit -am "Update project file to version ${SE_VERSION}"
+          git push
 
   build:
     name: Build

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-check:
+    name: Check Version for NuGet package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v4
+      - name: Get Speakeasy version
+        id: speakeasy_version
+        run: |
+          VERSION=$(./scripts/get-speakeasy-sdk-version.sh)
+          echo "speakeasy_version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Get .NET package version
+        id: dotnet_proj_version
+        run: |
+          VERSION=$(./scripts/get-csproj-version.sh Styra/Styra.csproj)
+          echo "dotnet_proj_version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Compare the two, failing if there's a diff.
+        if: ${{ steps.speakeasy_version.outputs.speakeasy_version != steps.dotnet_proj_version.outputs.dotnet_proj_version }}
+        run: |
+          SE_VERSION=${{ steps.speakeasy_version.outputs.speakeasy_version }}
+          DOTNET_VERSION=${{ steps.dotnet_proj_version.outputs.dotnet_proj_version }}
+          echo "Version mismatch. Speakeasy ver: ${SE_VERSION}, .NET project ver: ${DOTNET_VERSION}"
+          echo "To update the .NET project version, try this sed command, and then commit the changes:"
+          echo "  sed -i \"s/<Version>[^<]*<\/Version>/<Version>${SE_VERSION}<\/Version>/\" Styra/Styra.csproj"
+          exit 1
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Styra/Styra.csproj
+++ b/Styra/Styra.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>Styra</PackageId>
-    <Version>0.4.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Styra</Authors>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/scripts/get-csproj-version.sh
+++ b/scripts/get-csproj-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# This script extracts the .NET project version from a .csproj file.
+
+set -e
+
+usage() {
+    echo "Usage:" >&2
+    echo "  get-csproj-version.sh <FILE>" >&2
+}
+
+# Ensure README file exists.
+if [ ! -f $1 ]; then
+    echo "File '$1' not found!" >&2
+    usage
+    exit 1
+fi
+
+# Splits lines into fields, with `<` and `>` as the separators.
+awk -F'[><]' '/<Version>/{print $3}' $1

--- a/scripts/get-speakeasy-sdk-version.sh
+++ b/scripts/get-speakeasy-sdk-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# This script extracts the Speakeasy SDK version from `gen.yaml`.
+
+set -e
+
+usage() {
+    echo "Usage:" >&2
+    echo "  get-speakeasy-sdk-version.sh" >&2
+}
+
+# Ensure README file exists.
+if [ ! -f '.speakeasy/gen.yaml' ]; then
+    echo "File '$1' not found!" >&2
+    usage
+    exit 1
+fi
+
+# Relies on the `version` field occurring *exactly* once.
+awk '/version:/ {print $2; exit}' .speakeasy/gen.yaml


### PR DESCRIPTION
## What changed?

This commit adds new scripts for extracting version info from the .NET project files, and well as the Speakeasy configs. In the new GHA workflow job `version-check`, we pull both versions, compare them, and conditionally fail the job if there's a mismatch.

This extra PR check should catch cases where `speakeasy generate ...` was run locally, but the .NET project wasn't updated to match.

## TODOs

 - ~Add a `sed` script to update the .NET project file version whenever Speakeasy generate GHA workflows run.~ (EDIT: I'm going to do the scripting as a separate PR, since *this* PR is essentially shippable as-is.)