### PR TITLE
docs: Fix path issues in docs generation.

### DIFF
--- a/Styra/Opa/Styra.Opa.csproj
+++ b/Styra/Opa/Styra.Opa.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../README.md" Pack="true" PackagePath="/" />
-    <None Include="../docs/*" Pack="true" PackagePath="/docs" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+    <None Include="../../docs/*" Pack="true" PackagePath="/docs" />
 
     <PackageReference Include="newtonsoft.json" Version="13.0.3" />
     <PackageReference Include="nodatime" Version="3.1.9" />

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -43,7 +43,7 @@
           "files": [
             "*.csproj"
           ],
-          "src": "../Styra"
+          "src": "../Styra/Opa"
         }
       ]
     }

--- a/scripts/patch-readme.sh
+++ b/scripts/patch-readme.sh
@@ -26,11 +26,11 @@ if [ ! -f $1 ]; then
 fi
 
 # OpaApiClient SDK
-sed -i "s|(docs/sdks/opaapiclient/README.md)|($2/api/Styra.OpenApi.OpaApiClient.html)|g" $1
+sed -i "s|(docs/sdks/opaapiclient/README.md)|($2/api/Styra.Opa.OpenApi.OpaApiClient.html)|g" $1
 # ExecutePolicy
-sed -i "s|(docs/sdks/opaapiclient/README.md#executepolicy)|($2/api/Styra.OpenApi.OpaApiClient.html#Styra_OpenApi_OpaApiClient_ExecutePolicyAsync_Styra_OpenApi_Models_Requests_ExecutePolicyRequest_)|g" $1
+sed -i "s|(docs/sdks/opaapiclient/README.md#executepolicy)|($2/api/Styra.Opa.OpenApi.OpaApiClient.html#Styra_Opa_OpenApi_OpaApiClient_ExecutePolicyAsync_Styra_Opa_OpenApi_Models_Requests_ExecutePolicyRequest_)|g" $1
 # ExecutePolicyWithInput
-sed -i "s|(docs/sdks/opaapiclient/README.md#executepolicywithinput)|($2/api/Styra.OpenApi.OpaApiClient.html#Styra_OpenApi_OpaApiClient_ExecutePolicyWithInputAsync_Styra_OpenApi_Models_Requests_ExecutePolicyWithInputRequest_)|g" $1
+sed -i "s|(docs/sdks/opaapiclient/README.md#executepolicywithinput)|($2/api/Styra.Opa.OpenApi.OpaApiClient.html#Styra_Opa_OpenApi_OpaApiClient_ExecutePolicyWithInputAsync_Styra_Opa_OpenApi_Models_Requests_ExecutePolicyWithInputRequest_)|g" $1
 # Health
-sed -i "s|(docs/sdks/opaapiclient/README.md#health)|($2/api/Styra.OpenApi.OpaApiClient.html#Styra_OpenApi_OpaApiClient_HealthAsync_System_Nullable_System_Boolean__System_Nullable_System_Boolean__System_Collections_Generic_List_System_String__)|g" $1
+sed -i "s|(docs/sdks/opaapiclient/README.md#health)|($2/api/Styra.Opa.OpenApi.OpaApiClient.html#Styra_Opa_OpenApi_OpaApiClient_HealthAsync_System_Nullable_System_Boolean__System_Nullable_System_Boolean__System_Collections_Generic_List_System_String__)|g" $1
 


### PR DESCRIPTION
## What changed?

This PR fixes issues in documentation generation (and subsequent downstream NuGet publishing) that were caused by the big shakeup in package nesting that occurred in PR #26.