### PR TITLE
docs: Fix malformed XML comment.

### DIFF
--- a/Styra/Opa/OpenApi/Hooks/HookRegistration.cs
+++ b/Styra/Opa/OpenApi/Hooks/HookRegistration.cs
@@ -9,8 +9,8 @@ namespace Styra.Opa.OpenApi.Hooks
     public static class HookRegistration
     {
         /// <summary>
-        /// Add hooks by calling `Styra.Opa.OpenApi.Hooks.Register<HookInterface>(myHook);`
-        /// where `I<HookInterface>` is one of the following interfaces defined in HookTypes.cs:
+        /// Add hooks by calling `Styra.Opa.OpenApi.Hooks.Register&lt;HookInterface&gt;(myHook);`
+        /// where `I&lt;HookInterface&gt;` is one of the following interfaces defined in HookTypes.cs:
         ///   - ISDKInitHook
         ///   - IBeforeRequestHook
         ///   - IAfterSuccess


### PR DESCRIPTION
## What changed?

This PR fixes the warnings we've gotten around the malformed C# XML comments in `HooksRegistration.cs`.