### PR TITLE
test: Add DefaultPolicy test.

### DIFF
--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -15,17 +15,20 @@ public class OPAContainerFixture : IAsyncLifetime
         // Read in the test data files.
         var policy = System.IO.File.ReadAllBytes(Path.Combine("testdata", "policy.rego"));
         var secondPolicy = System.IO.File.ReadAllBytes(Path.Combine("testdata", "weird_name.rego"));
+        var systemPolicy = System.IO.File.ReadAllBytes(Path.Combine("testdata", "simple", "system.rego"));
         var data = System.IO.File.ReadAllBytes(Path.Combine("testdata", "data.json"));
+
 
         // Create a new instance of a container.
         IContainer container = new ContainerBuilder()
           .WithImage("openpolicyagent/opa:latest")
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
-          .WithCommand("run", "--server", "policy.rego", "weird_name.rego", "data.json")
+          .WithCommand("run", "--server", "policy.rego", "weird_name.rego", "system.rego", "data.json")
           // Map our policy and data files into the container instance.
           .WithResourceMapping(policy, "policy.rego")
           .WithResourceMapping(secondPolicy, "weird_name.rego")
+          .WithResourceMapping(systemPolicy, "system.rego")
           .WithResourceMapping(data, "data.json")
           // Wait until the HTTP endpoint of the container is available.
           .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))

--- a/test/SmokeTest.Tests/OpenApiTest.cs
+++ b/test/SmokeTest.Tests/OpenApiTest.cs
@@ -67,4 +67,39 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>
 
     Assert.Equal(true, resultMap?.GetValueOrDefault("allow", false));
   }
+
+  [Fact]
+  public async Task OpenApiClientEvaluateDefaultTest()
+  {
+    // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _container.Hostname, _container.GetMappedPublicPort(8181)).Uri;
+
+    // Send an HTTP GET request to the specified URI and retrieve the response as a string.
+    var client = new OpaApiClient(serverIndex: 0, serverUrl: requestUri.ToString());
+
+    // Exercise the low-level OPA C# SDK.
+    ExecuteDefaultPolicyWithInputRequest req = new ExecuteDefaultPolicyWithInputRequest()
+    {
+      Input = Input.CreateMapOfany(
+                    new Dictionary<string, object>() {
+                    { "user", "alice" },
+                    { "action", "read" },
+                    { "object", "id123" },
+                    { "type", "dog" },
+                    }),
+    };
+
+    // Note(philip): To to how the API is generated, we have to fire off
+    // requests directly-- there's no building of requests in advance for later
+    // launching.
+    var res = await client.ExecuteDefaultPolicyWithInputAsync(Input.CreateMapOfany(
+                    new Dictionary<string, object>() {
+                    { "hello", "world" },
+                    }));
+    var resultMap = res.Result?.MapOfany;
+
+    // Ensure we got back the expected fields from the eval.
+    Assert.Equal("this is the default path", resultMap?.GetValueOrDefault("msg", ""));
+    Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, resultMap?.GetValueOrDefault("echo", ""));
+  }
 }

--- a/test/SmokeTest.Tests/SmokeTest.Tests.csproj
+++ b/test/SmokeTest.Tests/SmokeTest.Tests.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <None Update="testdata\data.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="testdata\policy.rego" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="testdata\simple\system.rego" CopyToOutputDirectory="PreserveNewest" />
     <None Update="testdata\weird_name.rego" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/test/SmokeTest.Tests/testdata/simple/system.rego
+++ b/test/SmokeTest.Tests/testdata/simple/system.rego
@@ -1,0 +1,11 @@
+package system
+
+# This is used to exercise the default query functionality.
+
+msg := "this is the default path"
+
+main := x {
+    x := {"msg": msg, "echo": input}
+} else {
+    x := {"msg": msg}
+}


### PR DESCRIPTION
## What changed?

This PR includes a basic unit test to exercise the "default decision" / system policy feature of OPA. Currently, only OpenAPI tests are included. Later work may expose this to the high-level API too.