### PR TITLE
Styra/Opa: Add `evaluateDefault` methods.

### DIFF
--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -86,4 +86,17 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>
 
     Assert.False(allow);
   }
+
+  [Fact]
+  public async Task EvaluateDefaultTest()
+  {
+    var client = GetOpaClient();
+
+    Dictionary<string, object>? res = await client.evaluateDefault<Dictionary<string, object>>(
+      new Dictionary<string, object>() {
+        { "hello", "world" },
+      });
+
+    Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
+  }
 }

--- a/test/SmokeTest.Tests/OpenApiTest.cs
+++ b/test/SmokeTest.Tests/OpenApiTest.cs
@@ -77,18 +77,6 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>
     // Send an HTTP GET request to the specified URI and retrieve the response as a string.
     var client = new OpaApiClient(serverIndex: 0, serverUrl: requestUri.ToString());
 
-    // Exercise the low-level OPA C# SDK.
-    ExecuteDefaultPolicyWithInputRequest req = new ExecuteDefaultPolicyWithInputRequest()
-    {
-      Input = Input.CreateMapOfAny(
-                    new Dictionary<string, object>() {
-                    { "user", "alice" },
-                    { "action", "read" },
-                    { "object", "id123" },
-                    { "type", "dog" },
-                    }),
-    };
-
     // Note(philip): To to how the API is generated, we have to fire off
     // requests directly-- there's no building of requests in advance for later
     // launching.


### PR DESCRIPTION
## What changed?

This PR adds default server policy support to the higher-level `OpaClient` class with the new `evaluateDefault` method.

It supports all of the same types/methods as normal policies do under the usual `evaluate` method, which should make it convenient for folks who need to use it.