### PR TITLE
High-level Batch Query API Support

### DIFF
--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -58,6 +58,11 @@ public class OpaResult
 
     public static explicit operator OpaResult(ResponsesSuccessfulPolicyResponse e) => new OpaResult(e);
     public static explicit operator OpaResult(SuccessfulPolicyResponse e) => new OpaResult(e);
+
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
 }
 
 public class OpaError
@@ -95,14 +100,39 @@ public class OpaError
 
     public static explicit operator OpaError(OpenApi.Models.Components.ServerError e) => new OpaError(e);
     public static explicit operator OpaError(OpenApi.Models.Errors.ServerError e) => new OpaError(e);
+
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
 }
 
-public class OpaBatchInputs : Dictionary<string, Dictionary<string, object>> { }
+public class OpaBatchInputs : Dictionary<string, Dictionary<string, object>>
+{
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}
 
-public class OpaBatchResults : Dictionary<string, OpaResult> { }
+public class OpaBatchResults : Dictionary<string, OpaResult>
+{
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}
 
-public class OpaBatchErrors : Dictionary<string, OpaError> { }
+public class OpaBatchErrors : Dictionary<string, OpaError>
+{
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}
 
+// Used for preparing inputs to the Batch Query API, and converting result types
+// into useful higher-level types.
 public static class DictionaryExtensions
 {
     public static Dictionary<string, Input> ToOpaBatchInputRaw(this Dictionary<string, Dictionary<string, object>> inputs)

--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -568,7 +568,6 @@ public class OpaClient
             };
 
             // Launch query. The all-errors case is handled in the exception handler block.
-            // The other two possibilities (mixed and all-success) are handled further down.
             ExecuteBatchPolicyWithInputResponse res;
             try
             {
@@ -612,12 +611,12 @@ public class OpaClient
             }
             catch (SDKException se) when (se.StatusCode == 404)
             {
-                // We know we've got an issue now, try calling again.
+                // We know we've got an issue now.
                 opaSupportsBatchQueryAPI = false;
-                return await queryMachineryBatch(path, inputs);
+                // Fall-through to the "unsupported" case.
             }
         }
-        // Implicitly allow other exceptions through.
+        // Implicitly rethrow all other exceptions.
 
         // Fall back to sequential queries against the OPA instance.
         if (!opaSupportsBatchQueryAPI)

--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -3,12 +3,54 @@ namespace Styra.Opa;
 using OpenApi;
 using OpenApi.Models.Requests;
 using OpenApi.Models.Components;
+using OpenApi.Models.Errors;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Text.Json.Serialization;
 using System;
 using System.IO;
 using Newtonsoft.Json;
+
+public class OpaResult : SuccessfulPolicyResponse { }
+
+public class OpaError
+{
+    [JsonProperty("code")]
+    public string Code { get; set; } = default!;
+
+    [JsonProperty("decision_id")]
+    public string? DecisionId { get; set; }
+
+    [JsonProperty("message")]
+    public string Message { get; set; } = default!;
+
+    [JsonProperty("http_status_code")]
+    public string? HttpStatusCode { get; set; }
+
+    public OpaError()
+    {
+
+    }
+    public OpaError(Styra.Opa.OpenApi.Models.Components.ServerError err)
+    {
+        Code = err.Code;
+        DecisionId = err.DecisionId;
+        Message = err.Message;
+        HttpStatusCode = err.HttpStatusCode;
+    }
+    public OpaError(Styra.Opa.OpenApi.Models.Errors.ServerError err)
+    {
+        Code = err.Code;
+        DecisionId = err.DecisionId;
+        Message = err.Message;
+        HttpStatusCode = "500";
+    }
+}
+
+public class OpaBatchResults : Dictionary<string, OpaResult> { }
+
+public class OpaBatchErrors : Dictionary<string, OpaError> { }
+
 
 /// <summary>
 /// OpaClient provides high-level convenience APIs for interacting with an OPA server.
@@ -20,6 +62,11 @@ public class OpaClient
 
     // Default values to use when creating the SDK instance.
     private string sdkServerUrl = "http://localhost:8181";
+
+    // Internal: Records whether or not to go to fallback mode immediately for
+    // batched queries. It is switched over to false as soon as it gets a 404
+    // from an OPA server.
+    private bool opaSupportsBatchQueryAPI = true;
 
     // Values to use when generating requests.
     private bool policyRequestPretty = false;
@@ -114,7 +161,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, then coerce the result to type T.
+    /// Evaluate a policy, then coerce the result to type T.
     /// </summary>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
     /// <returns>Result, as an instance of T, or null in the case of a query failure.</returns>
@@ -124,7 +171,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, using the provided input boolean value, then coerce the result to type T.
+    /// Evaluate a policy, using the provided input boolean value, then coerce the result to type T.
     /// </summary>
     /// <param name="input">The input boolean value OPA will use for evaluating the rule.</param>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
@@ -135,7 +182,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, using the provided input floating-point number, then coerce the result to type T.
+    /// Evaluate a policy, using the provided input floating-point number, then coerce the result to type T.
     /// </summary>
     /// <param name="input">The input floating-point number OPA will use for evaluating the rule.</param>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
@@ -146,7 +193,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, using the provided input string, then coerce the result to type T.
+    /// Evaluate a policy, using the provided input string, then coerce the result to type T.
     /// </summary>
     /// <param name="input">The input string OPA will use for evaluating the rule.</param>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
@@ -157,7 +204,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, using the provided input boolean value, then coerce the result to type T.
+    /// Evaluate a policy, using the provided input boolean value, then coerce the result to type T.
     /// </summary>
     /// <param name="input">The input List value OPA will use for evaluating the rule.</param>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
@@ -169,7 +216,7 @@ public class OpaClient
     }
 
     /// <summary>
-    /// Evaluate the server's default policy, using the provided input map, then coerce the result to type T.
+    /// Evaluate a policy, using the provided input map, then coerce the result to type T.
     /// </summary>
     /// <param name="input">The input Dictionary OPA will use for evaluating the rule.</param>
     /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
@@ -182,25 +229,10 @@ public class OpaClient
     /// <exclude />
     private async Task<T?> queryMachinery<T>(string path, Input input)
     {
-        ExecutePolicyWithInputRequest req = new ExecutePolicyWithInputRequest()
-        {
-            Path = path,
-            RequestBody = new ExecutePolicyWithInputRequestBody()
-            {
-                Input = input
-            },
-            Pretty = policyRequestPretty,
-            Provenance = policyRequestProvenance,
-            Explain = policyRequestExplain,
-            Metrics = policyRequestMetrics,
-            Instrument = policyRequestInstrument,
-            StrictBuiltinErrors = policyRequestStrictBuiltinErrors,
-        };
-
         ExecutePolicyWithInputResponse res;
         try
         {
-            res = await opa.ExecutePolicyWithInputAsync(req);
+            res = await evalPolicySingle(path, input);
         }
         catch (Exception e)
         {
@@ -354,5 +386,159 @@ public class OpaClient
         // If we could not find a type present in the result that T derives
         // from or is, we return the appropriate null type for T.
         return default;
+    }
+
+    /// <summary>
+    /// Evaluate a policy, using the provided map of query inputs. Results will
+    /// be returned in an identically-structured pair of maps, one for
+    /// successful evals, and one for errors. In the event that the OPA server
+    /// does not support the /v1/batch/data endpoint, this method will fall back
+    /// to performing sequential queries against the OPA server.
+    /// </summary>
+    /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
+    /// <param name="inputs">The input Dictionary OPA will use for evaluating the rule. The keys are arbitrary ID strings, the values are the input values intended for each query.</param>
+    /// <returns>A pair of mappings, between string keys, and SuccessfulPolicyResponses, or ServerErrors.</returns>
+    public async Task<(OpaBatchResults, OpaBatchErrors)> evaluateBatch(string path, Dictionary<string, Input> inputs)
+    {
+        return await queryMachineryBatch(path, inputs);
+    }
+
+    /// <exclude />
+    private async Task<(OpaBatchResults, OpaBatchErrors)> queryMachineryBatch(string path, Dictionary<string, Input> inputs)
+    {
+        OpaBatchResults successResults = new();
+        OpaBatchErrors failureResults = new();
+
+        // Attempt using the /v1/batch/data endpoint. If we ever receive a 404, then it's a vanilla OPA instance, and we should skip straight to fallback mode.
+        if (opaSupportsBatchQueryAPI)
+        {
+            ExecuteBatchPolicyWithInputRequest req = new ExecuteBatchPolicyWithInputRequest()
+            {
+                Path = path,
+                RequestBody = new ExecuteBatchPolicyWithInputRequestBody()
+                {
+                    Inputs = inputs,
+                },
+                Pretty = policyRequestPretty,
+                Provenance = policyRequestProvenance,
+                Explain = policyRequestExplain,
+                Metrics = policyRequestMetrics,
+                Instrument = policyRequestInstrument,
+                StrictBuiltinErrors = policyRequestStrictBuiltinErrors,
+            };
+
+            // Launch query. The all-errors case is handled in the exception handler block.
+            // The other two possibilities (mixed and all-success) are handled further down.
+            ExecuteBatchPolicyWithInputResponse res;
+            try
+            {
+                res = await opa.ExecuteBatchPolicyWithInputAsync(req);
+            }
+            catch (Exception ex)
+            {
+                if (ex is ClientError ce)
+                {
+                    throw ce; // Rethrow for the caller to deal with. Request was malformed.
+                }
+                else if (ex is BatchServerError bse)
+                {
+                    foreach (var (key, value) in bse.Responses!) // Should not be null here.
+                    {
+                        failureResults.Add(key, new OpaError(value));
+                    }
+                    return (successResults, failureResults);
+                }
+                else
+                {
+                    throw; // Something unexpected blew up. Rethrow.
+                }
+            }
+
+            // All-success case.
+            if (res.StatusCode == 200)
+            {
+                foreach (var (key, value) in res.BatchSuccessfulPolicyEvaluation?.Responses!) // Should not be null here.
+                {
+                    successResults.Add(key, value as OpaResult);
+                }
+                return (successResults, failureResults);
+            }
+
+            // Mixed results case.
+            if (res.StatusCode == 207)
+            {
+                Dictionary<string, Responses> mixedResponses = res.BatchMixedResults?.Responses!; // Should not be null here.
+                foreach (var (key, value) in mixedResponses)
+                {
+                    switch (value.Type.ToString())
+                    {
+                        case "200":
+                            successResults.Add(key, new OpaResult()
+                            {
+                                DecisionId = value.ResponsesSuccessfulPolicyResponse?.DecisionId,
+                                Metrics = value.ResponsesSuccessfulPolicyResponse?.Metrics,
+                                Provenance = value.ResponsesSuccessfulPolicyResponse?.Provenance,
+                                Result = value.ResponsesSuccessfulPolicyResponse?.Result,
+                            });
+                            break;
+                        case "500":
+                            failureResults.Add(key, new OpaError(value.ServerError!)); // Should not be null.
+                            break;
+                    }
+                }
+                return (successResults, failureResults);
+            }
+            // TODO: Throw exception if we reach the end of this block without a successful return.
+        }
+
+        // Fall back to sequential queries against the OPA instance.
+        if (!opaSupportsBatchQueryAPI)
+        {
+            foreach (var (key, value) in inputs)
+            {
+                ExecutePolicyWithInputResponse res;
+                try
+                {
+                    res = await evalPolicySingle(path, value);
+                }
+                catch (Exception e)
+                {
+                    string msg = string.Format("executing policy at '{0}' with failed due to exception '{1}'", path, e);
+                    throw new OpaException(msg, e);
+                }
+
+                // We return the default null value for type T if Result is null.
+                var result = res.SuccessfulPolicyResponse?.Result;
+                if (result is null)
+                {
+                    return default;
+                }
+            }
+            return (successResults, failureResults);
+        }
+
+        // This *should* never happen. It means we didn't return from the batch or fallback handler blocks earlier.
+        throw new Exception("Impossible error");
+    }
+
+    /// <exclude />
+    private async Task<ExecutePolicyWithInputResponse> evalPolicySingle(string path, Input input)
+    {
+        ExecutePolicyWithInputRequest req = new ExecutePolicyWithInputRequest()
+        {
+            Path = path,
+            RequestBody = new ExecutePolicyWithInputRequestBody()
+            {
+                Input = input
+            },
+            Pretty = policyRequestPretty,
+            Provenance = policyRequestProvenance,
+            Explain = policyRequestExplain,
+            Metrics = policyRequestMetrics,
+            Instrument = policyRequestInstrument,
+            StrictBuiltinErrors = policyRequestStrictBuiltinErrors,
+        };
+
+        return await opa.ExecutePolicyWithInputAsync(req);
     }
 }

--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -8,6 +8,7 @@ using Styra.Opa.OpenApi.Models.Requests;
 using Styra.Opa.OpenApi.Models.Errors;
 
 namespace Styra.Opa;
+
 public class OpaResult
 {
     /// <summary>
@@ -34,6 +35,9 @@ public class OpaResult
     [JsonProperty("result")]
     public Result? Result { get; set; }
 
+    /// <summary>
+    /// The HTTP status code for the request. Limited to "200" or "500".
+    /// </summary>
     [JsonProperty("http_status_code")]
     public string? HttpStatusCode { get; set; }
 
@@ -67,15 +71,27 @@ public class OpaResult
 
 public class OpaError
 {
+    /// <summary>
+    /// The short-form category of error, such as "internal_error", "invalid_policy_or_data", etc.
+    /// </summary>
     [JsonProperty("code")]
     public string Code { get; set; } = default!;
 
+    /// <summary>
+    /// If decision logging is enabled, this field contains a string that uniquely identifies the decision. The identifier will be included in the decision log event for this decision. Callers can use the identifier for correlation purposes.
+    /// </summary>
     [JsonProperty("decision_id")]
     public string? DecisionId { get; set; }
 
+    /// <summary>
+    /// The long-form error message from the OPA instance, describing what went wrong.
+    /// </summary>
     [JsonProperty("message")]
     public string Message { get; set; } = default!;
 
+    /// <summary>
+    /// The HTTP status code for the request. Limited to "200" or "500".
+    /// </summary>
     [JsonProperty("http_status_code")]
     public string? HttpStatusCode { get; set; }
 
@@ -131,7 +147,7 @@ public class OpaBatchErrors : Dictionary<string, OpaError>
     }
 }
 
-// Used for preparing inputs to the Batch Query API, and converting result types
+// Used for converting inputs for the Batch Query API, and converting result types
 // into useful higher-level types.
 public static class DictionaryExtensions
 {

--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -111,7 +111,6 @@ public class OpaError
         Code = err.Code;
         DecisionId = err.DecisionId;
         Message = err.Message;
-        HttpStatusCode = "500";
     }
 
     public static explicit operator OpaError(OpenApi.Models.Components.ServerError e) => new OpaError(e);
@@ -593,6 +592,7 @@ public class OpaClient
                                     break;
                             }
                         }
+
                         return (successResults, failureResults);
                     default:
                         // TODO: Throw exception if we reach the end of this block without a successful return.

--- a/test/SmokeTest.Tests/EOPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/EOPAContainerFixture.cs
@@ -1,59 +1,55 @@
-using DotNet.Testcontainers.Containers;
-using Docker.DotNet.Models;
-using System.Runtime.InteropServices;
-
-namespace SmokeTest.Tests;
+﻿namespace SmokeTest.Tests;
 public class EOPAContainerFixture : IAsyncLifetime
 {
-    // Note: We disable this warning because we control when/how the constructor
-    // will be invoked for this class.
+  // Note: We disable this warning because we control when/how the constructor
+  // will be invoked for this class.
 #pragma warning disable CS8618
-    private IContainer _container;
-#pragma warning restore CS8618 
+  private IContainer _container;
+#pragma warning restore CS8618
 
-    public async Task InitializeAsync()
-    {
-        string[] startupFiles = {
+  public async Task InitializeAsync()
+  {
+    string[] startupFiles = {
             "testdata/policy.rego",
             "testdata/weird_name.rego",
             "testdata/simple/system.rego",
             "testdata/condfail.rego",
             "testdata/data.json"
         };
-        string[] opaCmd = { "run", "--server", "--addr=0.0.0.0:8181", "--disable-telemetry" };
-        string[] startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
+    string[] opaCmd = { "run", "--server", "--addr=0.0.0.0:8181", "--disable-telemetry" };
+    var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
-        // Create a new instance of a container.
-        IContainer container = new ContainerBuilder()
-          .WithImage("ghcr.io/styrainc/enterprise-opa:1.23.0")
-          .WithEnvironment("EOPA_LICENSE_TOKEN", Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN"))
-          .WithEnvironment("EOPA_LICENSE_KEY", Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY"))
-          // Bind port 8181 of the container to a random port on the host.
-          .WithPortBinding(8181, true)
-          .WithCommand(startupCommand)
-          // Map our policy and data files into the container instance.
-          .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
-          // Wait until the HTTP endpoint of the container is available.
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
-          //.WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole()) // DEBUG
-          // Build the container configuration.
-          .Build();
+    // Create a new instance of a container.
+    var container = new ContainerBuilder()
+      .WithImage("ghcr.io/styrainc/enterprise-opa:1.23.0")
+      .WithEnvironment("EOPA_LICENSE_TOKEN", Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN"))
+      .WithEnvironment("EOPA_LICENSE_KEY", Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY"))
+      // Bind port 8181 of the container to a random port on the host.
+      .WithPortBinding(8181, true)
+      .WithCommand(startupCommand)
+      // Map our policy and data files into the container instance.
+      .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
+      // Wait until the HTTP endpoint of the container is available.
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
+      //.WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole()) // DEBUG
+      // Build the container configuration.
+      .Build();
 
-        // Start the container.
-        await container.StartAsync()
-          .ConfigureAwait(false);
-        // DEBUG:
-        // var (stderr, stdout) = await container.GetLogsAsync(default);
-        // Console.WriteLine("STDERR: {0}", stderr);
-        // Console.WriteLine("STDOUT: {0}", stdout);
+    // Start the container.
+    await container.StartAsync()
+      .ConfigureAwait(false);
+    // DEBUG:
+    // var (stderr, stdout) = await container.GetLogsAsync(default);
+    // Console.WriteLine("STDERR: {0}", stderr);
+    // Console.WriteLine("STDOUT: {0}", stdout);
 
-        _container = container;
-    }
-    public async Task DisposeAsync()
-    {
-        await _container.DisposeAsync();
-    }
+    _container = container;
+  }
+  public async Task DisposeAsync()
+  {
+    await _container.DisposeAsync();
+  }
 
-    // Expose the container for tests
-    public IContainer GetContainer() => _container;
+  // Expose the container for tests
+  public IContainer GetContainer() => _container;
 }

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -1,20 +1,33 @@
+﻿using Newtonsoft.Json;
 using Styra.Opa;
+using Styra.Opa.OpenApi.Models.Components;
 
 namespace SmokeTest.Tests;
 
-public class HighLevelTest : IClassFixture<OPAContainerFixture>
+public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOPAContainerFixture>
 {
-  public IContainer _container;
+  public IContainer _containerOpa;
+  public IContainer _containerEopa;
 
-  public HighLevelTest(OPAContainerFixture fixture)
+  public HighLevelTest(OPAContainerFixture opaFixture, EOPAContainerFixture eopaFixture)
   {
-    _container = fixture.GetContainer();
+    _containerOpa = opaFixture.GetContainer();
+    _containerEopa = eopaFixture.GetContainer();
   }
 
   private OpaClient GetOpaClient()
   {
     // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
-    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _container.Hostname, _container.GetMappedPublicPort(8181)).Uri;
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerOpa.Hostname, _containerOpa.GetMappedPublicPort(8181)).Uri;
+
+    // Send an HTTP GET request to the specified URI and retrieve the response as a string.
+    return new OpaClient(serverUrl: requestUri.ToString());
+  }
+
+  private OpaClient GetEOpaClient()
+  {
+    // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerEopa.Hostname, _containerEopa.GetMappedPublicPort(8181)).Uri;
 
     // Send an HTTP GET request to the specified URI and retrieve the response as a string.
     return new OpaClient(serverUrl: requestUri.ToString());
@@ -92,11 +105,124 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>
   {
     var client = GetOpaClient();
 
-    Dictionary<string, object>? res = await client.evaluateDefault<Dictionary<string, object>>(
+    var res = await client.evaluateDefault<Dictionary<string, object>>(
       new Dictionary<string, object>() {
         { "hello", "world" },
       });
 
     Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
+  }
+
+  [Fact]
+  public async Task RBACBatchAllSuccessTest()
+  {
+    var client = GetEOpaClient();
+
+    var goodInput = new Dictionary<string, object>() {
+      { "user", "alice" },
+      { "action", "read" },
+      { "object", "id123" },
+      { "type", "dog" }
+    };
+
+    var (successes, failures) = await client.evaluateBatch("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
+      {"AAA", goodInput },
+      {"BBB", goodInput },
+      {"CCC", goodInput },
+    });
+
+    var expSuccess = new OpaResult() { Result = Result.CreateBoolean(true) };
+
+    // Assert that the successes dictionary has all expected elements, and the
+    // failures dictionary is empty.
+    Assert.Equivalent(new Dictionary<string, OpaResult>() {
+      { "AAA", expSuccess },
+      { "BBB", expSuccess },
+      { "CCC", expSuccess },
+    }, successes);
+    Assert.Empty(failures);
+  }
+
+  [Fact]
+  public async Task RBACBatchMixedTest()
+  {
+    var client = GetEOpaClient();
+
+    var goodInput = new Dictionary<string, object>() {
+      { "x", new List<int> {1, 1, 3} },
+      { "y", new List<int> {1, 1, 1} },
+    };
+
+    var badInput = new Dictionary<string, object>() {
+      { "x", new List<int> {1, 1, 3} },
+      { "y", new List<int> {1, 2, 1} },
+    };
+
+    var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+      {"AAA", badInput },
+      {"BBB", goodInput },
+      {"CCC", badInput },
+    });
+
+    var expSuccess = new OpaResult()
+    {
+      HttpStatusCode = "200",
+      Result = Result.CreateMapOfAny(
+        new Dictionary<string, object>() {
+          {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
+        }
+      )
+    };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "object insert conflict"
+    };
+
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResults() { { "BBB", expSuccess } }, successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
+      { "AAA", expError },
+      { "CCC", expError },
+    }, failures);
+
+  }
+
+  [Fact]
+  public async Task RBACBatchAllFailuresTest()
+  {
+    var client = GetEOpaClient();
+
+    var badInput = new Dictionary<string, object>() {
+      { "x", new List<int> {1, 1, 3} },
+      { "y", new List<int> {1, 2, 1} },
+    };
+
+    var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+      {"AAA", badInput },
+      {"BBB", badInput },
+      {"CCC", badInput },
+    });
+
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "object insert conflict"
+    };
+
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Empty(successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
+      { "AAA", expError },
+      { "BBB", expError },
+      { "CCC", expError },
+    }, failures);
+
   }
 }

--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -13,6 +13,7 @@ public class OPAContainerFixture : IAsyncLifetime
             "testdata/policy.rego",
             "testdata/weird_name.rego",
             "testdata/simple/system.rego",
+            "testdata/condfail.rego",
             "testdata/data.json"
         };
     string[] opaCmd = { "run", "--server" };

--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -1,49 +1,46 @@
-using DotNet.Testcontainers.Containers;
-using Docker.DotNet.Models;
-
-namespace SmokeTest.Tests;
+﻿namespace SmokeTest.Tests;
 public class OPAContainerFixture : IAsyncLifetime
 {
-    // Note: We disable this warning because we control when/how the constructor
-    // will be invoked for this class.
+  // Note: We disable this warning because we control when/how the constructor
+  // will be invoked for this class.
 #pragma warning disable CS8618
-    private IContainer _container;
-#pragma warning restore CS8618 
+  private IContainer _container;
+#pragma warning restore CS8618
 
-    public async Task InitializeAsync()
-    {
-        string[] startupFiles = {
+  public async Task InitializeAsync()
+  {
+    string[] startupFiles = {
             "testdata/policy.rego",
             "testdata/weird_name.rego",
             "testdata/simple/system.rego",
             "testdata/data.json"
         };
-        string[] opaCmd = { "run", "--server" };
-        string[] startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
+    string[] opaCmd = { "run", "--server" };
+    var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
-        // Create a new instance of a container.
-        IContainer container = new ContainerBuilder()
-          .WithImage("openpolicyagent/opa:latest")
-          // Bind port 8181 of the container to a random port on the host.
-          .WithPortBinding(8181, true)
-          .WithCommand(startupCommand)
-          // Map our policy and data files into the container instance.
-          .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
-          // Wait until the HTTP endpoint of the container is available.
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
-          // Build the container configuration.
-          .Build();
+    // Create a new instance of a container.
+    var container = new ContainerBuilder()
+      .WithImage("openpolicyagent/opa:latest")
+      // Bind port 8181 of the container to a random port on the host.
+      .WithPortBinding(8181, true)
+      .WithCommand(startupCommand)
+      // Map our policy and data files into the container instance.
+      .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
+      // Wait until the HTTP endpoint of the container is available.
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
+      // Build the container configuration.
+      .Build();
 
-        // Start the container.
-        await container.StartAsync()
-            .ConfigureAwait(false);
-        _container = container;
-    }
-    public async Task DisposeAsync()
-    {
-        await _container.DisposeAsync();
-    }
+    // Start the container.
+    await container.StartAsync()
+        .ConfigureAwait(false);
+    _container = container;
+  }
+  public async Task DisposeAsync()
+  {
+    await _container.DisposeAsync();
+  }
 
-    // Expose the container for tests
-    public IContainer GetContainer() => _container;
+  // Expose the container for tests
+  public IContainer GetContainer() => _container;
 }

--- a/test/SmokeTest.Tests/OpenApiTest.cs
+++ b/test/SmokeTest.Tests/OpenApiTest.cs
@@ -1,7 +1,7 @@
-using Styra.Opa.OpenApi;
-using Styra.Opa.OpenApi.Models.Requests;
+﻿using Styra.Opa.OpenApi;
 using Styra.Opa.OpenApi.Models.Components;
 using Styra.Opa.OpenApi.Models.Errors;
+using Styra.Opa.OpenApi.Models.Requests;
 
 namespace SmokeTest.Tests;
 
@@ -40,7 +40,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     var client = GetOpaApiClient();
 
     // Exercise the low-level OPA C# SDK.
-    ExecutePolicyWithInputRequest req = new ExecutePolicyWithInputRequest()
+    var req = new ExecutePolicyWithInputRequest()
     {
       Path = "app/rbac",
       RequestBody = new ExecutePolicyWithInputRequestBody()
@@ -70,7 +70,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     var client = GetOpaApiClient();
 
     // Exercise the low-level OPA C# SDK.
-    ExecutePolicyRequest req = new ExecutePolicyRequest()
+    var req = new ExecutePolicyRequest()
     {
       Path = "this/is%2fallowed/pkg",
     };
@@ -106,7 +106,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     // Currently, this API only exists in Enterprise OPA.
     var client = GetEOpaApiClient();
 
-    ExecuteBatchPolicyWithInputRequest req = new ExecuteBatchPolicyWithInputRequest()
+    var req = new ExecuteBatchPolicyWithInputRequest()
     {
       Path = "app/rbac",
       RequestBody = new ExecuteBatchPolicyWithInputRequestBody()
@@ -131,7 +131,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     // Currently, this API only exists in Enterprise OPA.
     var client = GetEOpaApiClient();
 
-    ExecuteBatchPolicyWithInputRequest req = new ExecuteBatchPolicyWithInputRequest()
+    var req = new ExecuteBatchPolicyWithInputRequest()
     {
       Path = "app/rbac",
       RequestBody = new ExecuteBatchPolicyWithInputRequestBody()
@@ -168,6 +168,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       Assert.NotNull(resp);
       Assert.Equal(true, resp?.Result?.MapOfAny?.GetValueOrDefault("allow"));
     }
+
     {
       var resp = responsesMap?.GetValueOrDefault("BBB");
       Assert.Equal(false, resp?.Result?.MapOfAny?.GetValueOrDefault("allow"));
@@ -180,7 +181,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     // Currently, this API only exists in Enterprise OPA.
     var client = GetEOpaApiClient();
 
-    ExecuteBatchPolicyWithInputRequest req = new ExecuteBatchPolicyWithInputRequest()
+    var req = new ExecuteBatchPolicyWithInputRequest()
     {
       Path = "testmod/condfail",
       RequestBody = new ExecuteBatchPolicyWithInputRequestBody()
@@ -220,6 +221,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       Assert.Equivalent(new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } }, resp?.ResponsesSuccessfulPolicyResponse?.Result?.MapOfAny?.GetValueOrDefault("p"));
       Assert.Equal("200", resp?.ResponsesSuccessfulPolicyResponse?.HttpStatusCode);
     }
+
     {
       var resp = responsesMap?.GetValueOrDefault("BBB");
       Assert.NotNull(resp?.ServerError);
@@ -227,6 +229,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       Assert.Equal("500", resp?.ServerError?.HttpStatusCode);
       Assert.Equal("object insert conflict", resp?.ServerError?.Message);
     }
+
     {
       var resp = responsesMap?.GetValueOrDefault("CCC");
       Assert.NotNull(resp);
@@ -241,7 +244,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     // Currently, this API only exists in Enterprise OPA.
     var client = GetEOpaApiClient();
 
-    ExecuteBatchPolicyWithInputRequest req = new ExecuteBatchPolicyWithInputRequest()
+    var req = new ExecuteBatchPolicyWithInputRequest()
     {
       Path = "testmod/condfail",
       RequestBody = new ExecuteBatchPolicyWithInputRequestBody()
@@ -280,7 +283,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     {
       if (ex is ClientError ce)
       {
-        Assert.Fail(String.Format("ClientError: {0}, Message: {1}", ce.Code, ce.Message));
+        Assert.Fail(string.Format("ClientError: {0}, Message: {1}", ce.Code, ce.Message));
       }
       else if (ex is BatchServerError bse)
       {
@@ -289,11 +292,11 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       }
       else if (ex is SDKException sdke)
       {
-        Assert.Fail(String.Format("SDKException: {0}, Message: {1}", sdke.Body, sdke.Message));
+        Assert.Fail(string.Format("SDKException: {0}, Message: {1}", sdke.Body, sdke.Message));
       }
       else
       {
-        Assert.Fail(String.Format("Unknown Error: {0}, Message: {1}", ex, ex.Message));
+        Assert.Fail(string.Format("Unknown Error: {0}, Message: {1}", ex, ex.Message));
       }
     }
 
@@ -305,8 +308,10 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       {
         Assert.Fail("Test failure due to OPA Fallback mode. Please check the EOPA license environment variables.");
       }
+
       Assert.Contains("object insert conflict", resp?.Message);
     }
+
     {
       var resp = responsesMap?.GetValueOrDefault("BBB");
       Assert.NotNull(resp);
@@ -315,8 +320,10 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       {
         Assert.Fail("Test failure due to OPA Fallback mode. Please check the EOPA license environment variables.");
       }
+
       Assert.Equal("object insert conflict", resp?.Message);
     }
+
     {
       var resp = responsesMap?.GetValueOrDefault("CCC");
       Assert.NotNull(resp);
@@ -325,6 +332,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
       {
         Assert.Fail("Test failure due to OPA Fallback mode. Please check the EOPA license environment variables.");
       }
+
       Assert.Equal("object insert conflict", resp?.Message);
     }
   }

--- a/test/SmokeTest.Tests/Usings.cs
+++ b/test/SmokeTest.Tests/Usings.cs
@@ -1,7 +1,3 @@
-global using Xunit;
-global using DotNet.Testcontainers;
+﻿global using Xunit;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Containers;
-global using DotNet.Testcontainers.Images;
-global using DotNet.Testcontainers.Networks;
-global using Newtonsoft.Json;


### PR DESCRIPTION
## What changed?

This PR adds new "high-level" Batch Query methods, and tests to prove that they work. It also incidentally required wiring up several new "OPA Types" for wrapping the lower-level error and result types generated by Speakeasy.

The new wrapper types all render as JSON objects when stringified, which is _much_ more helpful for debugging than the default behavior (which is just printing the type name of the C# object).

Exception handling has been refactored across the board to conform to C# norms a bit better, and some other minor refactors made it in as well.

## TODOs

 - [x] Clean up the wrapper types.
   - I've chosen to leave these in `Styra/Opa/OpaClient.cs` for now-- they can be split out into 1+ separate files later.
 - [x] More tests for the "fallback" case.
   - Caught some small bugs around the `HttpStatusCode` field while adding the additional cases, so it was a worthwhile task after all! :sweat_smile: 