### PR TITLE
Add support for arbitrary C# `object` types as inputs

### DIFF
--- a/Styra/Opa/OpaClient.cs
+++ b/Styra/Opa/OpaClient.cs
@@ -365,6 +365,33 @@ public class OpaClient
         return await queryMachinery<T>(path, Input.CreateMapOfAny(input));
     }
 
+    /// <summary>
+    /// Evaluate a policy, using the provided object, then coerce the result to
+    /// type T. This will round-trip an object through Newtonsoft.JsonConvert,
+    /// in order to generate the input object for the eventual OPA API call.
+    /// </summary>
+    /// <param name="input">The input IDictionary OPA will use for evaluating the rule.</param>
+    /// <param name="path">The rule to evaluate. (Example: "app/rbac")</param>
+    /// <returns>Result, as an instance of T, or null in the case of a query failure.</returns>
+    public async Task<T?> evaluate<T>(string path, object input)
+    {
+        if (input == null)
+        {
+            return default;
+        }
+
+        // Round-trip through JSON conversion, and deserialize it back to Dictionary<string, object>
+        var jsonInput = JsonConvert.SerializeObject(input);
+        var roundTrippedInput = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonInput);
+
+        if (roundTrippedInput is null)
+        {
+            return default;
+        }
+
+        return await queryMachinery<T>(path, Input.CreateMapOfAny(roundTrippedInput));
+    }
+
     /// <exclude />
     private async Task<T?> queryMachinery<T>(string path, Input input)
     {

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -269,6 +269,16 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   }
 
   [Fact]
+  public async Task EvaluateDefaultWithAnonymousObjectTest()
+  {
+    var client = GetOpaClient();
+
+    var res = await client.evaluateDefault<Dictionary<string, object>>(new { hello = "world" });
+
+    Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
+  }
+
+  [Fact]
   public async Task RBACBatchAllSuccessTest()
   {
     var client = GetEOpaClient();

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -100,6 +100,41 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   }
 
   [Fact]
+  public async Task DictionaryTypeCoerceTest()
+  {
+    //var client = GetOpaClient();
+    var client = new OpaClient(serverUrl: "http://localhost:8181");
+
+    var input = new Dictionary<string, string>() {
+      { "user", "alice" },
+      { "action", "read" },
+      { "object", "id123" },
+      { "type", "dog" },
+    };
+
+    var result = new Dictionary<string, object>();
+
+    try
+    {
+      result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
+    }
+    catch (OpaException e)
+    {
+      Console.WriteLine("exception while making request against OPA: " + e.Message);
+    }
+
+    var expected = new Dictionary<string, object>() {
+      { "allow", true },
+      { "user_is_admin", true },
+      { "user_is_granted", new List<object>()},
+    };
+
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
+
+  [Fact]
   public async Task EvaluateDefaultTest()
   {
     var client = GetOpaClient();


### PR DESCRIPTION
## What changed?

In this PR, `evaluate<T>` and `evaluateDefault<T>` now provide new method overloads, allowing arbitrary C# `object`'s as inputs to a policy. This makes the API *much* more ergonomic to use, at the expense of a bit of serdes overhead under-the-hood.

We serialize the incoming `object` type to JSON, and then attempt to convert it to a `Dictionary<string, object>`. This is reasonable in context, because other primitive JSON types *should* be matched by more specific methods, like the `string` or `double` methods, for instance.

Example (`evaluateDefault<T>`, anonymous object):
```csharp
var client = GetOpaClient();
var result = await client.evaluateDefault<Dictionary<string, object>>(new { hello = "world" });
```

Example (`evaluate<T>`, custom class object):
```csharp
private class CustomRBACObject
{

  [JsonProperty("user")]
  public string User = "";

  [JsonProperty("action")]
  public string Action = "";

  [JsonProperty("object")]
  public string Object = "";

  [JsonProperty("type")]
  public string Type = "";

  [JsonIgnore]
  public string UUID = System.Guid.NewGuid().ToString();

  public CustomRBACObject() { }

  public CustomRBACObject(string user, string action, string obj, string type)
  {
    User = user;
    Action = action;
    Object = obj;
    Type = type;
  }
}

// ...

var client = GetOpaClient();
var input = new CustomRBACObject("alice", "read", "id123", "dog");
var result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
```