### PR TITLE
Styra/Opa: Add evaluateBatch<T> support.

### DIFF
--- a/Styra/Opa/OpaBatchTypes.cs
+++ b/Styra/Opa/OpaBatchTypes.cs
@@ -20,6 +20,14 @@ public class OpaBatchResults : Dictionary<string, OpaResult>
     }
 }
 
+public class OpaBatchResultGeneric<T> : Dictionary<string, T>
+{
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}
+
 public class OpaBatchErrors : Dictionary<string, OpaError>
 {
     public override string ToString()
@@ -72,5 +80,15 @@ public static class DictionaryExtensions
             opaBatchResults[kvp.Key] = (OpaResult)kvp.Value;
         }
         return opaBatchResults;
+    }
+
+    public static OpaBatchResultGeneric<T> ToOpaBatchResults<T>(this Dictionary<string, SuccessfulPolicyResponse> responses)
+    {
+        var output = new OpaBatchResultGeneric<T>();
+        foreach (var kvp in responses)
+        {
+            output[kvp.Key] = OpaClient.convertResult<T>(kvp.Value.Result!);
+        }
+        return output;
     }
 }

--- a/Styra/Opa/Styra.Opa.csproj
+++ b/Styra/Opa/Styra.Opa.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>Styra.Opa</PackageId>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Authors>Styra</Authors>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## What changed?

This PR adds support for a variation of the `evaluateBatch` API, which allows returning a `Dictionary<string, T>`, instead of an `OpaBatchResults` type (`Dictionary<string, OpaResult>`).

This saves the caller a results-extraction step, and while it's a bit opinionated, it does make many normal usecases a lot cleaner.

## TODOs

 - [ ] Add an "expected exception" testcase for an API that returns 2x different success types, based on input.