### PR TITLE
test: Update to Rego v1 + add explicit `--addr` param for OPA fixture.

### DIFF
--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -16,7 +16,7 @@ public class OPAContainerFixture : IAsyncLifetime
             "testdata/condfail.rego",
             "testdata/data.json"
         };
-        string[] opaCmd = { "run", "--server" };
+        string[] opaCmd = { "run", "--server", "--addr=0.0.0.0:8181" };
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.

--- a/test/SmokeTest.Tests/testdata/simple/system.rego
+++ b/test/SmokeTest.Tests/testdata/simple/system.rego
@@ -1,11 +1,13 @@
 package system
 
+import rego.v1
+
 # This is used to exercise the default query functionality.
 
 msg := "this is the default path"
 
-main := x {
+main := x if {
     x := {"msg": msg, "echo": input}
-} else {
+} else if {
     x := {"msg": msg}
 }

--- a/test/SmokeTest.Tests/testdata/weird_name.rego
+++ b/test/SmokeTest.Tests/testdata/weird_name.rego
@@ -1,3 +1,5 @@
 package this["is/allowed"].pkg
 
+import rego.v1
+
 allow := true


### PR DESCRIPTION
## What changed?

This PR updates the test policies for the Rego v1 syntax, and adds a missing `--addr` parameter for the OPA test fixture that was causing the container to hang on startup.

The hang was caused by the testcontainer health check against port 8181 never succeeding.

Once this PR merges, it should unblock the #95 Dependabot PR that's been error-ing.