### PR TITLE
test: Add `OutputConsumer` settings to fixtures for better debugging.

### DIFF
--- a/test/SmokeTest.Tests/EOPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/EOPAContainerFixture.cs
@@ -1,4 +1,5 @@
 ﻿namespace SmokeTest.Tests;
+
 public class EOPAContainerFixture : IAsyncLifetime
 {
     // Note: We disable this warning because we control when/how the constructor
@@ -27,11 +28,12 @@ public class EOPAContainerFixture : IAsyncLifetime
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)
+          // Debugging aid, helpful if the Rego files have syntax errors.
+          .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
           // Map our policy and data files into the container instance.
           .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
           // Wait until the HTTP endpoint of the container is available.
           .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
-          //.WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole()) // DEBUG
           // Build the container configuration.
           .Build();
 

--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -25,6 +25,8 @@ public class OPAContainerFixture : IAsyncLifetime
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)
+          // Debugging aid, helpful if the Rego files have syntax errors.
+          .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
           // Map our policy and data files into the container instance.
           .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
           // Wait until the HTTP endpoint of the container is available.
@@ -35,6 +37,11 @@ public class OPAContainerFixture : IAsyncLifetime
         // Start the container.
         await container.StartAsync()
             .ConfigureAwait(false);
+        // DEBUG:
+        // var (stderr, stdout) = await container.GetLogsAsync(default);
+        // Console.WriteLine("STDERR: {0}", stderr);
+        // Console.WriteLine("STDOUT: {0}", stdout);
+
         _container = container;
     }
     public async Task DisposeAsync()


### PR DESCRIPTION
## What changed?

In the OPA ASP.NET Core SDK ([PR](https://github.com/StyraInc/opa-aspnetcore/pull/27)), this setting helped reveal a syntax error in the Rego that came up because of the OPA v1.0.0 upgrade. I thought I had adapted all of the code to be v1 compliant, but missed a single rule body, which caused the OPA container to not start. Without logs, it took a while to figure out what the issue really was.

If I'd had that logging in place from the beginning, it could've saved me a good bit of time, so I'm plumbing it in here for the sake of future maintainers.