### PR TITLE
Opa*: Add prealloc constructors/methods + style cleanups.

### DIFF
--- a/Styra/Opa/OpaBatchTypes.cs
+++ b/Styra/Opa/OpaBatchTypes.cs
@@ -6,6 +6,10 @@ namespace Styra.Opa;
 
 public class OpaBatchInputs : Dictionary<string, Dictionary<string, object>>
 {
+    public OpaBatchInputs() : base() { }
+
+    public OpaBatchInputs(int capacity) : base(capacity) { }
+
     public override string ToString()
     {
         return JsonConvert.SerializeObject(this);
@@ -14,6 +18,10 @@ public class OpaBatchInputs : Dictionary<string, Dictionary<string, object>>
 
 public class OpaBatchResults : Dictionary<string, OpaResult>
 {
+    public OpaBatchResults() : base() { }
+
+    public OpaBatchResults(int capacity) : base(capacity) { }
+
     public override string ToString()
     {
         return JsonConvert.SerializeObject(this);
@@ -22,6 +30,10 @@ public class OpaBatchResults : Dictionary<string, OpaResult>
 
 public class OpaBatchResultGeneric<T> : Dictionary<string, T>
 {
+    public OpaBatchResultGeneric() : base() { }
+
+    public OpaBatchResultGeneric(int capacity) : base(capacity) { }
+
     public override string ToString()
     {
         return JsonConvert.SerializeObject(this);
@@ -30,6 +42,10 @@ public class OpaBatchResultGeneric<T> : Dictionary<string, T>
 
 public class OpaBatchErrors : Dictionary<string, OpaError>
 {
+    public OpaBatchErrors() : base() { }
+
+    public OpaBatchErrors(int capacity) : base(capacity) { }
+
     public override string ToString()
     {
         return JsonConvert.SerializeObject(this);
@@ -42,7 +58,7 @@ public static class DictionaryExtensions
 {
     public static Dictionary<string, Input> ToOpaBatchInputRaw(this Dictionary<string, Dictionary<string, object>> inputs)
     {
-        var opaBatchInputs = new Dictionary<string, Input>();
+        var opaBatchInputs = new Dictionary<string, Input>(inputs.Count);
         foreach (var kvp in inputs)
         {
             opaBatchInputs[kvp.Key] = Input.CreateMapOfAny(kvp.Value);
@@ -53,7 +69,7 @@ public static class DictionaryExtensions
     // The OpenApi.Models.Errors variant of the ServerError type.
     public static OpaBatchErrors ToOpaBatchErrors(this Dictionary<string, Styra.Opa.OpenApi.Models.Errors.ServerError> errors)
     {
-        var opaBatchErrors = new OpaBatchErrors();
+        var opaBatchErrors = new OpaBatchErrors(errors.Count);
         foreach (var kvp in errors)
         {
             opaBatchErrors[kvp.Key] = new OpaError(kvp.Value);
@@ -64,7 +80,7 @@ public static class DictionaryExtensions
     // The OpenApi.Models.Components variant of the ServerError type.
     public static OpaBatchErrors ToOpaBatchErrors(this Dictionary<string, Styra.Opa.OpenApi.Models.Components.ServerErrorWithStatusCode> errors)
     {
-        var opaBatchErrors = new OpaBatchErrors();
+        var opaBatchErrors = new OpaBatchErrors(errors.Count);
         foreach (var kvp in errors)
         {
             opaBatchErrors[kvp.Key] = new OpaError(kvp.Value);
@@ -74,7 +90,7 @@ public static class DictionaryExtensions
 
     public static OpaBatchErrors ToOpaBatchErrors(this Dictionary<string, Styra.Opa.OpenApi.Models.Components.ServerError> errors)
     {
-        var opaBatchErrors = new OpaBatchErrors();
+        var opaBatchErrors = new OpaBatchErrors(errors.Count);
         foreach (var kvp in errors)
         {
             opaBatchErrors[kvp.Key] = new OpaError(kvp.Value);
@@ -84,17 +100,17 @@ public static class DictionaryExtensions
 
     public static OpaBatchResults ToOpaBatchResults(this Dictionary<string, SuccessfulPolicyResponse> responses)
     {
-        var opaBatchResults = new OpaBatchResults();
+        var opaBatchResults = new OpaBatchResults(responses.Count);
         foreach (var kvp in responses)
         {
-            opaBatchResults[kvp.Key] = (OpaResult)kvp.Value;
+            opaBatchResults[kvp.Key] = new OpaResult(kvp.Value);
         }
         return opaBatchResults;
     }
 
     public static OpaBatchResultGeneric<T> ToOpaBatchResults<T>(this Dictionary<string, SuccessfulPolicyResponse> responses)
     {
-        var output = new OpaBatchResultGeneric<T>();
+        var output = new OpaBatchResultGeneric<T>(responses.Count);
         foreach (var kvp in responses)
         {
             output[kvp.Key] = OpaClient.convertResult<T>(kvp.Value.Result!);

--- a/Styra/Opa/OpaError.cs
+++ b/Styra/Opa/OpaError.cs
@@ -55,8 +55,8 @@ public class OpaError
         Message = err.Message;
     }
 
-    public static explicit operator OpaError(OpenApi.Models.Components.ServerErrorWithStatusCode e) => new OpaError(e);
-    public static explicit operator OpaError(OpenApi.Models.Errors.ServerError e) => new OpaError(e);
+    public static explicit operator OpaError(OpenApi.Models.Components.ServerErrorWithStatusCode e) => new(e);
+    public static explicit operator OpaError(OpenApi.Models.Errors.ServerError e) => new(e);
 
     public override string ToString()
     {

--- a/Styra/Opa/OpaResult.cs
+++ b/Styra/Opa/OpaResult.cs
@@ -55,8 +55,8 @@ public class OpaResult
         Result = resp.Result;
     }
 
-    public static explicit operator OpaResult(SuccessfulPolicyResponseWithStatusCode e) => new OpaResult(e);
-    public static explicit operator OpaResult(SuccessfulPolicyResponse e) => new OpaResult(e);
+    public static explicit operator OpaResult(SuccessfulPolicyResponseWithStatusCode e) => new(e);
+    public static explicit operator OpaResult(SuccessfulPolicyResponse e) => new(e);
 
     public override string ToString()
     {


### PR DESCRIPTION
## What changed?

This PR includes support for preallocating several of our `Batch*` types, by explicitly wiring in the [capacity-based constructors](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.-ctor?view=net-9.0#system-collections-generic-dictionary-2-ctor(system-int32)) of the underlying base `Dictionary` types.

Methods that convert dictionaries also prealloc the result dictionary, which may be a significant performance boost for cases where a large number of entries are being wrangled.