### PR TITLE
WIP: Add Data Filters API surface

### DIFF
--- a/Styra/Opa/Filters/ColumnMasks.cs
+++ b/Styra/Opa/Filters/ColumnMasks.cs
@@ -1,0 +1,22 @@
+
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Styra.Ucast.Linq;
+
+namespace Styra.Opa.Filters;
+
+/// <summary>
+/// Wrapper type for the column masking rule objects EOPA generates alongside data filtering results.
+/// </summary>
+public class ColumnMasks : Dictionary<string, Dictionary<string, MaskingFunc>>
+{
+    public ColumnMasks() : base() { }
+
+    public ColumnMasks(int capacity) : base(capacity) { }
+
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}

--- a/Styra/Opa/Filters/CompileOptions.cs
+++ b/Styra/Opa/Filters/CompileOptions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Styra.Opa.Filters;
+
+public class CompileOptions
+{
+    /// <summary>
+    /// A list of paths to exclude from partial evaluation inlining.
+    /// </summary>
+    [JsonProperty("disableInlining")]
+    public List<string>? DisableInlining { get; set; }
+
+    /// <summary>
+    /// The output targets for partial evaluation. Different targets will have different constraints.
+    /// </summary>
+    [JsonProperty("targetDialects")]
+    public List<TargetDialects>? TargetDialects { get; set; }
+
+    [JsonProperty("targetSQLTableMappings")]
+    public TargetSQLTableMappings? TargetSQLTableMappings { get; set; }
+
+    /// <summary>
+    /// The Rego rule to evaluate for generating column masks.
+    /// </summary>
+    [JsonProperty("maskRule")]
+    public string? MaskRule { get; set; }
+}

--- a/Styra/Opa/Filters/Filters.cs
+++ b/Styra/Opa/Filters/Filters.cs
@@ -1,0 +1,21 @@
+
+
+using Newtonsoft.Json;
+using Styra.Ucast.Linq;
+
+namespace Styra.Opa.Filters;
+
+// TODO: Figure out what we want to do here. Polymorphism? A discriminated union type?
+
+/// <summary>
+/// Wrapper type for the UCAST data filters EOPA generates.
+/// </summary>
+public class Filters : UCASTNode
+{
+    public Filters() : base() { }
+
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}

--- a/Styra/Opa/Filters/TargetDialect.cs
+++ b/Styra/Opa/Filters/TargetDialect.cs
@@ -1,0 +1,57 @@
+
+using System;
+using Newtonsoft.Json;
+
+namespace Styra.Opa.Filters;
+
+public enum TargetDialects
+{
+    [JsonProperty("ucast+all")]
+    UcastPlusAll,
+    [JsonProperty("ucast+minimal")]
+    UcastPlusMinimal,
+    [JsonProperty("ucast+prisma")]
+    UcastPlusPrisma,
+    [JsonProperty("ucast+linq")]
+    UcastPlusLinq,
+    [JsonProperty("sql+sqlserver")]
+    SqlPlusSqlserver,
+    [JsonProperty("sql+mysql")]
+    SqlPlusMysql,
+    [JsonProperty("sql+postgresql")]
+    SqlPlusPostgresql,
+    [JsonProperty("sql+sqlite")]
+    SqlPlusSqlite,
+}
+
+public static class TargetDialectsExtension
+{
+    public static string Value(this TargetDialects value)
+    {
+        return ((JsonPropertyAttribute)value.GetType().GetMember(value.ToString())[0].GetCustomAttributes(typeof(JsonPropertyAttribute), false)[0]).PropertyName ?? value.ToString();
+    }
+
+    public static TargetDialects ToEnum(this string value)
+    {
+        foreach (var field in typeof(TargetDialects).GetFields())
+        {
+            var attributes = field.GetCustomAttributes(typeof(JsonPropertyAttribute), false);
+            if (attributes.Length == 0)
+            {
+                continue;
+            }
+
+            if (attributes[0] is JsonPropertyAttribute attribute && attribute.PropertyName == value)
+            {
+                var enumVal = field.GetValue(null);
+
+                if (enumVal is TargetDialects dialects)
+                {
+                    return dialects;
+                }
+            }
+        }
+
+        throw new Exception($"Unknown value {value} for enum TargetDialects");
+    }
+}

--- a/Styra/Opa/Filters/TargetSQLTableMappings.cs
+++ b/Styra/Opa/Filters/TargetSQLTableMappings.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Styra.Opa.Filters;
+
+public class TargetSQLTableMappings
+{
+    [JsonProperty("sqlserver")]
+    public Dictionary<string, object>? Sqlserver { get; set; }
+
+    [JsonProperty("mysql")]
+    public Dictionary<string, object>? Mysql { get; set; }
+
+    [JsonProperty("postgresql")]
+    public Dictionary<string, object>? Postgresql { get; set; }
+
+    [JsonProperty("sqlite")]
+    public Dictionary<string, object>? Sqlite { get; set; }
+}

--- a/Styra/Opa/LogMessages.cs
+++ b/Styra/Opa/LogMessages.cs
@@ -6,6 +6,14 @@ namespace Styra.Opa;
 
 internal static partial class LogMessages
 {
+
+    [LoggerMessage(
+        Message = "DEBUG: {message}",
+        Level = LogLevel.Debug)]
+    internal static partial void LogDebug(
+        this ILogger logger,
+        string message);
+
     [LoggerMessage(
         Message = "Batch Query API unavailable, falling back to sequential OPA queries",
         Level = LogLevel.Warning)]

--- a/Styra/Opa/OpaBatchTypes.cs
+++ b/Styra/Opa/OpaBatchTypes.cs
@@ -113,7 +113,7 @@ public static class DictionaryExtensions
         var output = new OpaBatchResultGeneric<T>(responses.Count);
         foreach (var kvp in responses)
         {
-            output[kvp.Key] = OpaClient.convertResult<T>(kvp.Value.Result!);
+            output[kvp.Key] = OpaClient.ConvertResult<T>(kvp.Value.Result!);
         }
         return output;
     }

--- a/Styra/Opa/Styra.Opa.csproj
+++ b/Styra/Opa/Styra.Opa.csproj
@@ -20,5 +20,6 @@
     <PackageReference Include="nodatime" Version="3.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="Styra.Ucast.Linq" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/test/SmokeTest.Tests/EOPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/EOPAContainerFixture.cs
@@ -15,14 +15,16 @@ public class EOPAContainerFixture : IAsyncLifetime
             "testdata/weird_name.rego",
             "testdata/simple/system.rego",
             "testdata/condfail.rego",
-            "testdata/data.json"
+            "testdata/data.json",
+            "testdata/filters/filters.rego",
+            "testdata/filters/roles.json"
         };
-        string[] opaCmd = { "run", "--server", "--addr=0.0.0.0:8181", "--disable-telemetry" };
+        string[] opaCmd = ["run", "--server", "--addr=0.0.0.0:8181", "--disable-telemetry"];
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.
         var container = new ContainerBuilder()
-          .WithImage("ghcr.io/styrainc/enterprise-opa:1.23.0")
+          .WithImage("ghcr.io/styrainc/enterprise-opa:latest")
           .WithEnvironment("EOPA_LICENSE_TOKEN", Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN"))
           .WithEnvironment("EOPA_LICENSE_KEY", Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY"))
           // Bind port 8181 of the container to a random port on the host.

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -9,335 +9,336 @@ namespace SmokeTest.Tests;
 // Used to verify presence of log messages in tests.
 public class ListLogger : ILogger<OpaClient>
 {
-    public List<string> Logs { get; } = new List<string>();
+  public List<string> Logs { get; } = new List<string>();
 
-    IDisposable ILogger.BeginScope<TState>(TState state)
+  IDisposable ILogger.BeginScope<TState>(TState state)
+  {
+    return null!;
+  }
+
+  public bool IsEnabled(LogLevel logLevel) => true;
+
+  public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+  {
+    if (formatter == null) { throw new ArgumentNullException(nameof(formatter)); }
+    ;
+
+    var message = formatter(state, exception);
+    if (!string.IsNullOrEmpty(message))
     {
-        return null!;
+      Logs.Add(message);
     }
-
-    public bool IsEnabled(LogLevel logLevel) => true;
-
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-    {
-        if (formatter == null) { throw new ArgumentNullException(nameof(formatter)); };
-
-        var message = formatter(state, exception);
-        if (!string.IsNullOrEmpty(message))
-        {
-            Logs.Add(message);
-        }
-    }
+  }
 }
 
 // Note(philip): Run with `--logger "console;verbosity=detailed"` to see logged messages.
 public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOPAContainerFixture>
 {
-    private readonly ITestOutputHelper _testOutput;
-    public IContainer _containerOpa;
-    public IContainer _containerEopa;
+  private readonly ITestOutputHelper _testOutput;
+  public IContainer _containerOpa;
+  public IContainer _containerEopa;
 
-    private class CustomRBACInputObject
-    {
+  private class CustomRBACInputObject
+  {
 
-        [JsonProperty("user")]
-        public string? User;
+    [JsonProperty("user")]
+    public string? User;
 
-        [JsonProperty("action")]
-        public string? Action;
+    [JsonProperty("action")]
+    public string? Action;
 
-        [JsonProperty("object")]
-        public string? Object;
+    [JsonProperty("object")]
+    public string? Object;
 
-        [JsonProperty("type")]
-        public string? Type;
+    [JsonProperty("type")]
+    public string? Type;
 
-        [JsonIgnore]
-        public string UUID = System.Guid.NewGuid().ToString();
+    [JsonIgnore]
+    public string UUID = System.Guid.NewGuid().ToString();
 
-        public CustomRBACInputObject() { }
-    }
+    public CustomRBACInputObject() { }
+  }
 
-    public class CustomRBACOutputObject
-    {
-        [JsonProperty("allow")]
-        public bool Allow = false;
+  public class CustomRBACOutputObject
+  {
+    [JsonProperty("allow")]
+    public bool Allow = false;
 
-        [JsonProperty("user_is_admin")]
-        public bool? IsAdmin;
+    [JsonProperty("user_is_admin")]
+    public bool? IsAdmin;
 
-        [JsonProperty("user_is_granted")]
-        public List<object>? Grants;
+    [JsonProperty("user_is_granted")]
+    public List<object>? Grants;
 
-        public CustomRBACOutputObject() { }
-    }
+    public CustomRBACOutputObject() { }
+  }
 
-    public HighLevelTest(OPAContainerFixture opaFixture, EOPAContainerFixture eopaFixture, ITestOutputHelper output)
-    {
-        _containerOpa = opaFixture.GetContainer();
-        _containerEopa = eopaFixture.GetContainer();
-        _testOutput = output;
-    }
+  public HighLevelTest(OPAContainerFixture opaFixture, EOPAContainerFixture eopaFixture, ITestOutputHelper output)
+  {
+    _containerOpa = opaFixture.GetContainer();
+    _containerEopa = eopaFixture.GetContainer();
+    _testOutput = output;
+  }
 
-    private OpaClient GetOpaClient()
-    {
-        // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
-        var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerOpa.Hostname, _containerOpa.GetMappedPublicPort(8181)).Uri;
-        return new OpaClient(serverUrl: requestUri.ToString());
-    }
+  private OpaClient GetOpaClient()
+  {
+    // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerOpa.Hostname, _containerOpa.GetMappedPublicPort(8181)).Uri;
+    return new OpaClient(serverUrl: requestUri.ToString());
+  }
 
-    private OpaClient GetOpaClientWithLogger(ILogger<OpaClient> logger)
-    {
-        var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerOpa.Hostname, _containerOpa.GetMappedPublicPort(8181)).Uri;
-        return new OpaClient(serverUrl: requestUri.ToString(), logger: logger);
-    }
+  private OpaClient GetOpaClientWithLogger(ILogger<OpaClient> logger)
+  {
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerOpa.Hostname, _containerOpa.GetMappedPublicPort(8181)).Uri;
+    return new OpaClient(serverUrl: requestUri.ToString(), logger: logger);
+  }
 
-    private OpaClient GetEOpaClient()
-    {
-        var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerEopa.Hostname, _containerEopa.GetMappedPublicPort(8181)).Uri;
-        return new OpaClient(serverUrl: requestUri.ToString());
-    }
+  private OpaClient GetEOpaClient()
+  {
+    var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerEopa.Hostname, _containerEopa.GetMappedPublicPort(8181)).Uri;
+    return new OpaClient(serverUrl: requestUri.ToString());
+  }
 
-    [Fact]
-    public async Task RBACCheckDictionaryTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACCheckDictionaryTest()
+  {
+    var client = GetOpaClient();
 
-        var allow = await client.check("app/rbac/allow", new Dictionary<string, object>() {
+    var allow = await client.Check("app/rbac/allow", new Dictionary<string, object>() {
       { "user", "alice" },
       { "action", "read" },
       { "object", "id123" },
       { "type", "dog" },
     });
 
-        // BUG: This can fail as long as Speakeasy generates the upstream SDK with
-        // deserializers occurring in the same ordering as the OpenAPI spec.
-        Assert.True(allow);
-    }
+    // BUG: This can fail as long as Speakeasy generates the upstream SDK with
+    // deserializers occurring in the same ordering as the OpenAPI spec.
+    Assert.True(allow);
+  }
 
-    [Fact]
-    public async Task RBACCheckNullTest()
+  [Fact]
+  public async Task RBACCheckNullTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", null);
+
+    Assert.False(allow);
+  }
+
+  [Fact]
+  public async Task RBACCheckBoolTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", true);
+
+    Assert.False(allow);
+  }
+
+  [Fact]
+  public async Task RBACCheckDoubleTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", 42);
+
+    Assert.False(allow);
+  }
+
+  [Fact]
+  public async Task RBACCheckStringTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", "alice");
+
+    Assert.False(allow);
+  }
+
+  [Fact]
+  public async Task RBACCheckListObjTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", new List<object>() { "A", "B", "C", "D" });
+
+    Assert.False(allow);
+  }
+
+  [Fact]
+  public async Task RBACCheckAnonymousObjectTest()
+  {
+    var client = GetOpaClient();
+
+    var allow = await client.Check("app/rbac/allow", new
     {
-        var client = GetOpaClient();
+      user = "alice",
+      action = "read",
+      _object = "id123",
+      type = "dog"
+    });
 
-        var allow = await client.check("app/rbac/allow", null);
+    Assert.True(allow);
+  }
 
-        Assert.False(allow);
-    }
+  [Fact]
+  public async Task DictionaryTypeCoerceTest()
+  {
+    var client = GetOpaClient();
 
-    [Fact]
-    public async Task RBACCheckBoolTest()
-    {
-        var client = GetOpaClient();
-
-        var allow = await client.check("app/rbac/allow", true);
-
-        Assert.False(allow);
-    }
-
-    [Fact]
-    public async Task RBACCheckDoubleTest()
-    {
-        var client = GetOpaClient();
-
-        var allow = await client.check("app/rbac/allow", 42);
-
-        Assert.False(allow);
-    }
-
-    [Fact]
-    public async Task RBACCheckStringTest()
-    {
-        var client = GetOpaClient();
-
-        var allow = await client.check("app/rbac/allow", "alice");
-
-        Assert.False(allow);
-    }
-
-    [Fact]
-    public async Task RBACCheckListObjTest()
-    {
-        var client = GetOpaClient();
-
-        var allow = await client.check("app/rbac/allow", new List<object>() { "A", "B", "C", "D" });
-
-        Assert.False(allow);
-    }
-
-    [Fact]
-    public async Task RBACCheckAnonymousObjectTest()
-    {
-        var client = GetOpaClient();
-
-        var allow = await client.check("app/rbac/allow", new
-        {
-            user = "alice",
-            action = "read",
-            _object = "id123",
-            type = "dog"
-        });
-
-        Assert.True(allow);
-    }
-
-    [Fact]
-    public async Task DictionaryTypeCoerceTest()
-    {
-        var client = GetOpaClient();
-
-        var input = new Dictionary<string, string>() {
+    var input = new Dictionary<string, string>() {
       { "user", "alice" },
       { "action", "read" },
       { "object", "id123" },
       { "type", "dog" },
     };
 
-        var result = new Dictionary<string, object>();
+    var result = new Dictionary<string, object>();
 
-        try
-        {
-            result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
+    try
+    {
+      result = await client.Evaluate<Dictionary<string, object>>("app/rbac", input);
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
+    }
 
-        var expected = new Dictionary<string, object>() {
+    var expected = new Dictionary<string, object>() {
       { "allow", true },
       { "user_is_admin", true },
       { "user_is_granted", new List<object>()},
     };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
-        Assert.Equal(expected.Count, result.Count);
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
+
+  [Fact]
+  public async Task BooleanInputTypeCoerceTest()
+  {
+    var client = GetOpaClient();
+
+    var input = false;
+
+    var result = new Dictionary<string, object>();
+
+    try
+    {
+      result = await client.Evaluate<Dictionary<string, object>>("app/rbac", input);
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
     }
 
-    [Fact]
-    public async Task BooleanInputTypeCoerceTest()
-    {
-        var client = GetOpaClient();
-
-        var input = false;
-
-        var result = new Dictionary<string, object>();
-
-        try
-        {
-            result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
-
-        var expected = new Dictionary<string, object>() {
+    var expected = new Dictionary<string, object>() {
       { "allow", false },
       { "user_is_granted", new List<object>()},
     };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
-        Assert.Equal(expected.Count, result.Count);
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
+
+  [Fact]
+  public async Task CustomClassInputTypeCoerceTest()
+  {
+    var client = GetOpaClient();
+
+    var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
+
+    var result = new Dictionary<string, object>();
+
+    try
+    {
+      result = await client.Evaluate<Dictionary<string, object>>("app/rbac", input);
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
     }
 
-    [Fact]
-    public async Task CustomClassInputTypeCoerceTest()
-    {
-        var client = GetOpaClient();
-
-        var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
-
-        var result = new Dictionary<string, object>();
-
-        try
-        {
-            result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
-
-        var expected = new Dictionary<string, object>() {
+    var expected = new Dictionary<string, object>() {
       { "allow", true },
       { "user_is_admin", true },
       { "user_is_granted", new List<object>()},
     };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
-        Assert.Equal(expected.Count, result.Count);
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
+
+  [Fact]
+  public async Task CustomClassOutputTypeCoerceTest()
+  {
+    var client = GetOpaClient();
+
+    var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
+
+    var result = new CustomRBACOutputObject();
+    try
+    {
+      var res = await client.Evaluate<CustomRBACOutputObject>("app/rbac", input);
+      if (res is CustomRBACOutputObject value)
+      {
+        result = value;
+      }
+      else
+      {
+        Assert.Fail("Test did not deserialize to a custom C# type properly.");
+      }
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
     }
 
-    [Fact]
-    public async Task CustomClassOutputTypeCoerceTest()
+    var expected = new CustomRBACOutputObject()
     {
-        var client = GetOpaClient();
+      Allow = true,
+      IsAdmin = true,
+      Grants = new List<object>(),
+    };
 
-        var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+  }
 
-        var result = new CustomRBACOutputObject();
-        try
-        {
-            var res = await client.evaluate<CustomRBACOutputObject>("app/rbac", input);
-            if (res is CustomRBACOutputObject value)
-            {
-                result = value;
-            }
-            else
-            {
-                Assert.Fail("Test did not deserialize to a custom C# type properly.");
-            }
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
+  [Fact]
+  public async Task BadOutputTypeCoerceTest()
+  {
+    var client = GetOpaClient();
 
-        var expected = new CustomRBACOutputObject()
-        {
-            Allow = true,
-            IsAdmin = true,
-            Grants = new List<object>(),
-        };
+    var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
+    // Attempt to coerce an object return type into a bool. This should always fail!
+    await Assert.ThrowsAsync<OpaException>(async () => { var res = await client.Evaluate<bool>("app/rbac", input); });
+  }
+
+  [Fact]
+  public async Task CustomClassInputTypeCoerceJsonSettingsTest()
+  {
+    var client = GetOpaClient();
+
+    var input = new { a = "A", b = (object)null!, c = 2 }; // We will ensure the null field is not serialized.
+
+    var result = new Dictionary<string, object>();
+
+    try
+    {
+      result = await client.Evaluate<Dictionary<string, object>>("system/main", input, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
     }
 
-    [Fact]
-    public async Task BadOutputTypeCoerceTest()
-    {
-        var client = GetOpaClient();
-
-        var input = new CustomRBACInputObject() { User = "alice", Action = "read", Object = "id123", Type = "dog" };
-
-        // Attempt to coerce an object return type into a bool. This should always fail!
-        await Assert.ThrowsAsync<OpaException>(async () => { var res = await client.evaluate<bool>("app/rbac", input); });
-    }
-
-    [Fact]
-    public async Task CustomClassInputTypeCoerceJsonSettingsTest()
-    {
-        var client = GetOpaClient();
-
-        var input = new { a = "A", b = (object)null!, c = 2 }; // We will ensure the null field is not serialized.
-
-        var result = new Dictionary<string, object>();
-
-        try
-        {
-            result = await client.evaluate<Dictionary<string, object>>("system/main", input, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
-
-        var expected = new Dictionary<string, object>() {
+    var expected = new Dictionary<string, object>() {
       { "msg", "this is the default path" },
       { "echo", new Dictionary<string, object>() {
         { "a", "A" },
@@ -345,532 +346,532 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
       } },
     };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
-        Assert.Equal(expected.Count, result.Count);
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
+
+  [Fact]
+  public async Task AnonymousObjectInputTypeCoerceTest()
+  {
+    var client = GetOpaClient();
+
+    // Relies on Newtonsoft.Json's default serialization rules. `object` is unused by
+    // the policy, thankfully, so we can get away with mangling that field's name.
+    var input = new { user = "alice", action = "read", _object = "id123", type = "dog" };
+
+    var result = new Dictionary<string, object>();
+
+    try
+    {
+      result = await client.Evaluate<Dictionary<string, object>>("app/rbac", input);
+    }
+    catch (OpaException e)
+    {
+      _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
     }
 
-    [Fact]
-    public async Task AnonymousObjectInputTypeCoerceTest()
-    {
-        var client = GetOpaClient();
-
-        // Relies on Newtonsoft.Json's default serialization rules. `object` is unused by
-        // the policy, thankfully, so we can get away with mangling that field's name.
-        var input = new { user = "alice", action = "read", _object = "id123", type = "dog" };
-
-        var result = new Dictionary<string, object>();
-
-        try
-        {
-            result = await client.evaluate<Dictionary<string, object>>("app/rbac", input);
-        }
-        catch (OpaException e)
-        {
-            _testOutput.WriteLine("exception while making request against OPA: " + e.Message);
-        }
-
-        var expected = new Dictionary<string, object>() {
+    var expected = new Dictionary<string, object>() {
       { "allow", true },
       { "user_is_admin", true },
       { "user_is_granted", new List<object>()},
     };
 
-        Assert.NotNull(result);
-        Assert.Equivalent(expected, result);
-        Assert.Equal(expected.Count, result.Count);
-    }
+    Assert.NotNull(result);
+    Assert.Equivalent(expected, result);
+    Assert.Equal(expected.Count, result.Count);
+  }
 
-    [Fact]
-    public async Task EvaluateDefaultTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task EvaluateDefaultTest()
+  {
+    var client = GetOpaClient();
 
-        var res = await client.evaluateDefault<Dictionary<string, object>>(
-          new Dictionary<string, object>() {
+    var res = await client.EvaluateDefault<Dictionary<string, object>>(
+      new Dictionary<string, object>() {
         { "hello", "world" },
-          });
+      });
 
-        Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
-    }
+    Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
+  }
 
-    [Fact]
-    public async Task EvaluateDefaultWithAnonymousObjectInputTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task EvaluateDefaultWithAnonymousObjectInputTest()
+  {
+    var client = GetOpaClient();
 
-        var res = await client.evaluateDefault<Dictionary<string, object>>(new { hello = "world" });
+    var res = await client.EvaluateDefault<Dictionary<string, object>>(new { hello = "world" });
 
-        Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
-    }
+    Assert.Equal(new Dictionary<string, object>() { { "hello", "world" } }, res?.GetValueOrDefault("echo", ""));
+  }
 
-    [Fact]
-    public async Task RBACBatchAllSuccessTest()
-    {
-        var client = GetEOpaClient();
+  [Fact]
+  public async Task RBACBatchAllSuccessTest()
+  {
+    var client = GetEOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "user", "alice" },
       { "action", "read" },
       { "object", "id123" },
       { "type", "dog" }
     };
 
-        var (successes, failures) = await client.evaluateBatch("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", goodInput },
       {"BBB", goodInput },
       {"CCC", goodInput },
     });
 
-        var expSuccess = new OpaResult() { Result = Result.CreateBoolean(true) };
+    var expSuccess = new OpaResult() { Result = Result.CreateBoolean(true) };
 
-        // Assert that the successes dictionary has all expected elements, and the
-        // failures dictionary is empty.
-        Assert.Equivalent(new Dictionary<string, OpaResult>() {
+    // Assert that the successes dictionary has all expected elements, and the
+    // failures dictionary is empty.
+    Assert.Equivalent(new Dictionary<string, OpaResult>() {
       { "AAA", expSuccess },
       { "BBB", expSuccess },
       { "CCC", expSuccess },
     }, successes);
-        Assert.Empty(failures);
-    }
+    Assert.Empty(failures);
+  }
 
-    [Fact]
-    public async Task RBACBatchMixedTest()
-    {
-        var client = GetEOpaClient();
+  [Fact]
+  public async Task RBACBatchMixedTest()
+  {
+    var client = GetEOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 1, 1} },
     };
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", goodInput },
       {"CCC", badInput },
     });
 
-        var expSuccess = new OpaResult()
-        {
-            HttpStatusCode = "200",
-            Result = Result.CreateMapOfAny(
-            new Dictionary<string, object>() {
+    var expSuccess = new OpaResult()
+    {
+      HttpStatusCode = "200",
+      Result = Result.CreateMapOfAny(
+        new Dictionary<string, object>() {
           {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
-            }
-          )
-        };
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            HttpStatusCode = "500",
-            Message = "object insert conflict"
-        };
+        }
+      )
+    };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "object insert conflict"
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Equivalent(new OpaBatchResults() { { "BBB", expSuccess } }, successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResults() { { "BBB", expSuccess } }, successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchAllFailuresTest()
-    {
-        var client = GetEOpaClient();
+  [Fact]
+  public async Task RBACBatchAllFailuresTest()
+  {
+    var client = GetEOpaClient();
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", badInput },
       {"CCC", badInput },
     });
 
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            Message = "object insert conflict"
-        };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      Message = "object insert conflict"
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Empty(successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Empty(successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "BBB", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchAllSuccessFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchAllSuccessFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 1, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", goodInput },
       {"BBB", goodInput },
       {"CCC", goodInput },
     });
 
-        var expSuccess = new OpaResult()
-        {
-            Result = Result.CreateMapOfAny(
-            new Dictionary<string, object>() {
+    var expSuccess = new OpaResult()
+    {
+      Result = Result.CreateMapOfAny(
+        new Dictionary<string, object>() {
           {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
-            }
-          )
-        };
+        }
+      )
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Equivalent(new OpaBatchResults() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResults() {
       { "BBB", expSuccess },
       { "AAA", expSuccess },
       { "CCC", expSuccess }
     }, successes);
-        Assert.Empty(failures);
+    Assert.Empty(failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchMixedFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchMixedFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 1, 1} },
     };
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", goodInput },
       {"CCC", badInput },
     });
 
-        var expSuccess = new OpaResult()
-        {
-            HttpStatusCode = "200",
-            Result = Result.CreateMapOfAny(
-            new Dictionary<string, object>() {
+    var expSuccess = new OpaResult()
+    {
+      HttpStatusCode = "200",
+      Result = Result.CreateMapOfAny(
+        new Dictionary<string, object>() {
           {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
-            }
-          )
-        };
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            HttpStatusCode = "500",
-            Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
-        };
+        }
+      )
+    };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Equivalent(new OpaBatchResults() { { "BBB", expSuccess } }, successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResults() { { "BBB", expSuccess } }, successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchAllFailuresFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchAllFailuresFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", badInput },
       {"CCC", badInput },
     });
 
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
-        };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Empty(successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Empty(successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "BBB", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    // The generic version of the batch queries.
-    [Fact]
-    public async Task RBACBatchGenericAllSuccessTest()
-    {
-        var client = GetEOpaClient();
+  // The generic version of the batch queries.
+  [Fact]
+  public async Task RBACBatchGenericAllSuccessTest()
+  {
+    var client = GetEOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "user", "alice" },
       { "action", "read" },
       { "object", "id123" },
       { "type", "dog" }
     };
 
-        var (successes, failures) = await client.evaluateBatch<bool>("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<bool>("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", goodInput },
       {"BBB", goodInput },
       {"CCC", goodInput },
     });
 
-        var expSuccess = true;
+    var expSuccess = true;
 
-        // Assert that the successes dictionary has all expected elements, and the
-        // failures dictionary is empty.
-        Assert.Equivalent(new Dictionary<string, object>() {
+    // Assert that the successes dictionary has all expected elements, and the
+    // failures dictionary is empty.
+    Assert.Equivalent(new Dictionary<string, object>() {
       { "AAA", expSuccess },
       { "BBB", expSuccess },
       { "CCC", expSuccess },
     }, successes);
-        Assert.Empty(failures);
-    }
+    Assert.Empty(failures);
+  }
 
-    [Fact]
-    public async Task RBACBatchGenericMixedTest()
-    {
-        var client = GetEOpaClient();
+  [Fact]
+  public async Task RBACBatchGenericMixedTest()
+  {
+    var client = GetEOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 1, 1} },
     };
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", goodInput },
       {"CCC", badInput },
     });
 
-        var expSuccess =
-            new Dictionary<string, object>() {
+    var expSuccess =
+        new Dictionary<string, object>() {
           {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
-            };
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            HttpStatusCode = "500",
-            Message = "object insert conflict"
         };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "object insert conflict"
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Equivalent(new OpaBatchResultGeneric<Dictionary<string, object>>() { { "BBB", expSuccess } }, successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResultGeneric<Dictionary<string, object>>() { { "BBB", expSuccess } }, successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchGenericAllFailuresTest()
-    {
-        var client = GetEOpaClient();
+  [Fact]
+  public async Task RBACBatchGenericAllFailuresTest()
+  {
+    var client = GetEOpaClient();
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", badInput },
       {"CCC", badInput },
     });
 
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            Message = "object insert conflict"
-        };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      Message = "object insert conflict"
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Empty(successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Empty(successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "BBB", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchGenericAllSuccessFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchGenericAllSuccessFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "user", "alice" },
       { "action", "read" },
       { "object", "id123" },
       { "type", "dog" }
     };
 
-        var (successes, failures) = await client.evaluateBatch<bool>("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<bool>("app/rbac/allow", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", goodInput },
       {"BBB", goodInput },
       {"CCC", goodInput },
     });
 
-        var expSuccess = true;
+    var expSuccess = true;
 
-        // Assert that the successes dictionary has all expected elements, and the
-        // failures dictionary is empty.
-        Assert.Equivalent(new Dictionary<string, object>() {
+    // Assert that the successes dictionary has all expected elements, and the
+    // failures dictionary is empty.
+    Assert.Equivalent(new Dictionary<string, object>() {
       { "AAA", expSuccess },
       { "BBB", expSuccess },
       { "CCC", expSuccess },
     }, successes);
-        Assert.Empty(failures);
-    }
+    Assert.Empty(failures);
+  }
 
-    [Fact]
-    public async Task RBACBatchGenericMixedFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchGenericMixedFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var goodInput = new Dictionary<string, object>() {
+    var goodInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 1, 1} },
     };
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", goodInput },
       {"CCC", badInput },
     });
 
-        var expSuccess =
-            new Dictionary<string, object>() {
+    var expSuccess =
+        new Dictionary<string, object>() {
           {"p", new Dictionary<string, object>() { { "1", 2 }, { "3", 4 } } }
-            };
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            HttpStatusCode = "500",
-            Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
         };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      HttpStatusCode = "500",
+      Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Equivalent(new OpaBatchResultGeneric<Dictionary<string, object>>() { { "BBB", expSuccess } }, successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Equivalent(new OpaBatchResultGeneric<Dictionary<string, object>>() { { "BBB", expSuccess } }, successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task RBACBatchGenericAllFailuresFallbackTest()
-    {
-        var client = GetOpaClient();
+  [Fact]
+  public async Task RBACBatchGenericAllFailuresFallbackTest()
+  {
+    var client = GetOpaClient();
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        var (successes, failures) = await client.evaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
+    var (successes, failures) = await client.EvaluateBatch<Dictionary<string, object>>("testmod/condfail", new Dictionary<string, Dictionary<string, object>>() {
       {"AAA", badInput },
       {"BBB", badInput },
       {"CCC", badInput },
     });
 
-        var expError = new OpaError()
-        {
-            Code = "internal_error",
-            DecisionId = null,
-            Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
-        };
+    var expError = new OpaError()
+    {
+      Code = "internal_error",
+      DecisionId = null,
+      Message = "error(s) occurred while evaluating query" // Note: different error message for OPA mode.
+    };
 
-        // Assert that the failures dictionary has all expected elements, and the
-        // successes dictionary is empty.
-        Assert.Empty(successes);
-        Assert.Equivalent(new Dictionary<string, OpaError>() {
+    // Assert that the failures dictionary has all expected elements, and the
+    // successes dictionary is empty.
+    Assert.Empty(successes);
+    Assert.Equivalent(new Dictionary<string, OpaError>() {
       { "AAA", expError },
       { "BBB", expError },
       { "CCC", expError },
     }, failures);
 
-    }
+  }
 
-    [Fact]
-    public async Task LogsExistTest()
-    {
-        var logger = new ListLogger();
-        var client = GetOpaClientWithLogger(logger);
+  [Fact]
+  public async Task LogsExistTest()
+  {
+    var logger = new ListLogger();
+    var client = GetOpaClientWithLogger(logger);
 
-        var badInput = new Dictionary<string, object>() {
+    var badInput = new Dictionary<string, object>() {
       { "x", new List<int> {1, 1, 3} },
       { "y", new List<int> {1, 2, 1} },
     };
 
-        try
-        {
-            var result = await client.evaluate<bool>("testmod/condfail", badInput);
-        }
-        catch (OpaException e)
-        {
-            // Do nothing.
-            _testOutput.WriteLine(e.Message);
-        }
-
-        Assert.Single(logger.Logs);
-        Assert.Contains("executing policy 'testmod/condfail' failed with exception: ", logger.Logs[0]);
+    try
+    {
+      var result = await client.Evaluate<bool>("testmod/condfail", badInput);
     }
+    catch (OpaException e)
+    {
+      // Do nothing.
+      _testOutput.WriteLine(e.Message);
+    }
+
+    Assert.Single(logger.Logs);
+    Assert.Contains("executing policy 'testmod/condfail' failed with exception: ", logger.Logs[0]);
+  }
 }


### PR DESCRIPTION
## What changed?

This PR wraps up the state of work so far on adding Enterprise OPA's
Data Filters feature, which uses the extended Compile API to generate
data filters and column masking rules from Rego policies.

Currently, we have to manually work around a codegen bug in Speakeasy,
so the low-level machinery is just manually assembling the HTTP request
the hard way.

## TODO

 - [ ] Finish debugging why the filter policy is not loading up correctly in the EOPA container for the HL tests.