### PR TITLE
ci: Add `permissions` to Actions workflows.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,6 +66,8 @@ jobs:
   docs-updates-needed:
     name: Docs Update Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
@@ -78,6 +80,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
@@ -94,6 +98,8 @@ jobs:
   smoke-test:
     name: Smoke Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR adds [`permissions`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) blocks to each job in the PR workflow, which should resolve some repo security warnings, and maybe a few test-related issues.


