### PR TITLE
test: Refactor to xunit.v3 + Skip EOPA tests when unlicensed.

### DIFF
--- a/test/SmokeTest.Tests/EOPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/EOPAContainerFixture.cs
@@ -8,7 +8,7 @@ public class EOPAContainerFixture : IAsyncLifetime
     private IContainer _container;
 #pragma warning restore CS8618
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         string[] startupFiles = {
             "testdata/policy.rego",
@@ -49,7 +49,7 @@ public class EOPAContainerFixture : IAsyncLifetime
 
         _container = container;
     }
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _container.DisposeAsync();
     }

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -4,7 +4,6 @@ using Styra.Opa;
 using Styra.Opa.Filters;
 using Styra.Opa.OpenApi.Models.Components;
 using Styra.Ucast.Linq;
-using Xunit.Abstractions;
 
 namespace SmokeTest.Tests;
 
@@ -104,6 +103,13 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     {
         var requestUri = new UriBuilder(Uri.UriSchemeHttp, _containerEopa.Hostname, _containerEopa.GetMappedPublicPort(8181)).Uri;
         return new OpaClient(serverUrl: requestUri.ToString(), logger: logger);
+    }
+
+    private bool NoEOPALicenseEnvVarsFound()
+    {
+        var key = Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY") ?? "";
+        var token = Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN") ?? "";
+        return key == "" && token == "";
     }
 
     [Fact]
@@ -415,6 +421,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchAllSuccessTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var goodInput = new Dictionary<string, object>() {
@@ -445,6 +452,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchMixedTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var goodInput = new Dictionary<string, object>() {
@@ -493,6 +501,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchAllFailuresTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var badInput = new Dictionary<string, object>() {
@@ -646,6 +655,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchGenericAllSuccessTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var goodInput = new Dictionary<string, object>() {
@@ -676,6 +686,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchGenericMixedTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var goodInput = new Dictionary<string, object>() {
@@ -719,6 +730,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task RBACBatchGenericAllFailuresTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var badInput = new Dictionary<string, object>() {
@@ -860,6 +872,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task GetFiltersTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var (filters, masks) = await client.GetFilters("filters/include", new Dictionary<string, object>
@@ -911,6 +924,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task GetFiltersWithMasksTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         // Result here should be identical to the filters-oriented test, but our
@@ -938,6 +952,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task GetFiltersMultiTargetTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         var (filters, masks) = await client.GetMultipleFilters("filters/include", new Dictionary<string, object>()
@@ -1003,6 +1018,7 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
     [Fact]
     public async Task GetFiltersMultiTargetWithMasksTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         var client = GetEOpaClient();
 
         // Result here should be identical to the filters-oriented test, but our

--- a/test/SmokeTest.Tests/OPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/OPAContainerFixture.cs
@@ -1,4 +1,6 @@
-﻿namespace SmokeTest.Tests;
+﻿
+namespace SmokeTest.Tests;
+
 public class OPAContainerFixture : IAsyncLifetime
 {
     // Note: We disable this warning because we control when/how the constructor
@@ -7,7 +9,7 @@ public class OPAContainerFixture : IAsyncLifetime
     private IContainer _container;
 #pragma warning restore CS8618
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         string[] startupFiles = {
             "testdata/policy.rego",
@@ -44,7 +46,7 @@ public class OPAContainerFixture : IAsyncLifetime
 
         _container = container;
     }
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _container.DisposeAsync();
     }

--- a/test/SmokeTest.Tests/OpenApiTest.cs
+++ b/test/SmokeTest.Tests/OpenApiTest.cs
@@ -35,6 +35,13 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
         return new OpaApiClient(serverIndex: 0, serverUrl: requestUri.ToString());
     }
 
+    private bool NoEOPALicenseEnvVarsFound()
+    {
+        var key = Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY") ?? "";
+        var token = Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN") ?? "";
+        return key == "" && token == "";
+    }
+
     [Fact]
     public async Task OpenApiClientRBACTestcontainersTest()
     {
@@ -104,6 +111,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     [Fact]
     public async Task OpenApiClientBatchPolicyNoInputTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         // Currently, this API only exists in Enterprise OPA.
         var client = GetEOpaApiClient();
 
@@ -129,6 +137,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     [Fact]
     public async Task OpenApiClientBatchPolicyAllSuccessTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         // Currently, this API only exists in Enterprise OPA.
         var client = GetEOpaApiClient();
 
@@ -179,6 +188,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     [Fact]
     public async Task OpenApiClientBatchPolicyMixedTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         // Currently, this API only exists in Enterprise OPA.
         var client = GetEOpaApiClient();
 
@@ -242,6 +252,7 @@ public class OpenApiTest : IClassFixture<OPAContainerFixture>, IClassFixture<EOP
     [Fact]
     public async Task OpenApiClientBatchPolicyAllFailureTest()
     {
+        Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
         // Currently, this API only exists in Enterprise OPA.
         var client = GetEOpaApiClient();
 

--- a/test/SmokeTest.Tests/SmokeTest.Tests.csproj
+++ b/test/SmokeTest.Tests/SmokeTest.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Testcontainers" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="2.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR upgrades the repo to use [xUnit v3](https://www.nuget.org/packages/xunit.v3), and the [skip assertions](https://api.xunit.net/v3/2.0.2/v3.2.0.2-Xunit.Assert.SkipWhen.html) it provides. Those allow us to simply skip Enterprise OPA-specific feature tests when the license environment variables are not provided.
