### PR TITLE
Release v1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.6.6
+
+This release updates the help text hints for Data Filters to point at the upstream OPA Compile API documentation.
+
 
 ## 1.6.2, 1.6.3, 1.6.4, 1.6.5
 
-These releases contain release engineering fixes, with no significant code or dependency changes. contains release engineering improvements, including support for publishing Github Releases again.
+These releases release engineering improvements, including support for publishing Github Releases again.
 
 
 ## 1.6.1

--- a/src/OpenPolicyAgent.Opa/Filters/ColumnMasks.cs
+++ b/src/OpenPolicyAgent.Opa/Filters/ColumnMasks.cs
@@ -9,7 +9,7 @@ namespace OpenPolicyAgent.Opa.Filters;
 /// <summary>
 /// Wrapper type for the column masking rule objects EOPA generates alongside data filtering results.
 /// </summary>
-/// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/data-filtering/explanation/column-masks.md"/></remarks>
+/// <remarks>See: <see href="https://www.openpolicyagent.org/docs/filtering/column-masks"/></remarks>
 public class ColumnMasks : Dictionary<string, Dictionary<string, MaskingFunc>>
 {
     public ColumnMasks() : base() { }

--- a/src/OpenPolicyAgent.Opa/Filters/TargetDialect.cs
+++ b/src/OpenPolicyAgent.Opa/Filters/TargetDialect.cs
@@ -8,7 +8,7 @@ namespace OpenPolicyAgent.Opa.Filters;
 /// An enum of all data filter formats that EOPA supports in the Compile API.
 /// Used in the <c>options.targetDialects</c> payload field, and for <c>Accept</c> header selection.
 /// </summary>
-/// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md"/></remarks>
+/// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#compile-api"/></remarks>
 public enum TargetDialects
 {
     [JsonProperty("ucast+all")]
@@ -65,7 +65,7 @@ public static class TargetDialectsExtension
     /// </summary>
     /// <param name="value">The TargetDialects value to use.</param>
     /// <returns>An <c>Accept</c> header string of the format <c>application/vnd.opa.${data_filter_type}+json</c>.</returns>
-    /// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md#accept-header--controlling-the-target-response-format"/></remarks>
+    /// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#accept-header--controlling-the-target-response-format"/></remarks>
     public static string ToAcceptHeader(this TargetDialects value)
     {
         return value switch
@@ -88,7 +88,7 @@ public static class TargetDialectsExtension
     /// </summary>
     /// <param name="value">The TargetDialects value to use.</param>
     /// <returns>A dialect string for the <c>options.targetDialects</c> payload field.</returns>
-    /// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md#request-body"/></remarks>
+    /// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#request-body-1"/></remarks>
     public static string ToOptionString(this TargetDialects value)
     {
         return value switch

--- a/src/OpenPolicyAgent.Opa/Filters/TargetSQLTableMappings.cs
+++ b/src/OpenPolicyAgent.Opa/Filters/TargetSQLTableMappings.cs
@@ -7,7 +7,7 @@ namespace OpenPolicyAgent.Opa.Filters;
 /// Mapping between tables and columns for the EOPA Compile API.
 /// Used in the <c>options.targetSQLTableMappings</c> payload field.
 /// </summary>
-/// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md#request-body"/></remarks>
+/// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#request-body-1"/></remarks>
 public class TargetSQLTableMappings
 {
     [JsonProperty("sqlserver")]

--- a/src/OpenPolicyAgent.Opa/OpaClient.cs
+++ b/src/OpenPolicyAgent.Opa/OpaClient.cs
@@ -491,7 +491,7 @@ public class OpaClient
     /// <param name="jsonSerializerSettings">The Newtonsoft.Json.JsonSerializerSettings object to use for round-tripping the input through JSON serdes. (default: global serializer settings, if any)</param>
     /// <returns>A ValueTuple of data filters (UCAST nodes or SQL) and column masking rules (if present).</returns>
     /// <exception cref="OpaException"></exception>
-    /// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md"/></remarks>
+    /// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#compile-api"/></remarks>
     public async Task<(IFilter, ColumnMasks?)> GetFilters(string path, object? input, List<string>? unknowns = null, Filters.TargetSQLTableMappings? tableMappings = null, Filters.TargetDialects targetDialect = Filters.TargetDialects.UcastLinq, JsonSerializerSettings? jsonSerializerSettings = null)
     {
         if (input is null)
@@ -523,7 +523,7 @@ public class OpaClient
     /// <param name="jsonSerializerSettings">The Newtonsoft.Json.JsonSerializerSettings object to use for round-tripping the input through JSON serdes. (default: global serializer settings, if any)</param>
     /// <returns>A ValueTuple of data filters (UCAST nodes or SQL) and column masking rules (if present).</returns>
     /// <exception cref="OpaException"></exception>
-    /// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md"/></remarks>
+    /// <remarks>See: <see href="https://www.openpolicyagent.org/docs/rest-api#compile-api"/></remarks>
     public async Task<(Dictionary<string, IFilter>, ColumnMasks?)> GetMultipleFilters(string path, object? input, List<string>? unknowns = null, Filters.TargetSQLTableMappings? tableMappings = null, List<Filters.TargetDialects>? targetDialects = null, JsonSerializerSettings? jsonSerializerSettings = null)
     {
         if (input is null)

--- a/src/OpenPolicyAgent.Opa/OpenPolicyAgent.Opa.csproj
+++ b/src/OpenPolicyAgent.Opa/OpenPolicyAgent.Opa.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>OpenPolicyAgent.Opa</PackageId>
-    <Version>1.6.5</Version>
+    <Version>1.6.6</Version>
     <Authors>The OPA Authors</Authors>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This release updates the help text seen in intellisense documentation to point to the new [Compile API docs](https://www.openpolicyagent.org/docs/rest-api#compile-api), instead of various markdown files in the EOPA repo.

### :chains: Related Resources

